### PR TITLE
feat: Monitor Tier 1–4 presentation (carry/convexity chart, Tier-2 gauges, Part X reorg)

### DIFF
--- a/deltadewa/visualization/__init__.py
+++ b/deltadewa/visualization/__init__.py
@@ -10,10 +10,14 @@ Date: 2026-01-12
 
 from deltadewa.visualization.base import OptionCharts
 from deltadewa.visualization.convenience import plot_greeks_consolidated
-from deltadewa.visualization.crash_charts import plot_crash_convexity
+from deltadewa.visualization.crash_charts import (
+    plot_carry_vs_convexity,
+    plot_crash_convexity,
+)
 
 __all__ = [
     "OptionCharts",
+    "plot_carry_vs_convexity",
     "plot_crash_convexity",
     "plot_greeks_consolidated",
 ]

--- a/deltadewa/visualization/crash_charts.py
+++ b/deltadewa/visualization/crash_charts.py
@@ -12,6 +12,7 @@ from deltadewa.colours import DEFAULT_PALETTE
 
 if TYPE_CHECKING:
     from deltadewa.analysis.crash_payoff import CrashConvexityResult
+    from deltadewa.ips_config import IpsConvexity
 
 
 def plot_crash_convexity(
@@ -129,8 +130,125 @@ def plot_crash_convexity(
     return fig
 
 
+def plot_carry_vs_convexity(
+    *,
+    carry_cost: float | None,
+    convexity_pct: float | None,
+    ips_convexity: IpsConvexity | None = None,
+    ax: Axes | None = None,
+) -> Figure:
+    """Carry cost vs crash convexity — cost-vs-protection view.
+
+    Plots the current book as a single point on a cost (Y-axis) vs
+    protection (X-axis) plane.  When *ips_convexity* is supplied, the
+    target convexity band is shaded on the X axis.
+
+    Consumes pre-computed scalars only; does not reprice the portfolio.
+
+    Args:
+        carry_cost: Annual carry cost in dollars (e.g.
+            ``calculate_carry_metrics()["total_theta_annual"]``).
+            Negative for net-long-premium books.  ``None`` renders a
+            labelled empty figure.
+        convexity_pct: Net crash P&L as % of book notional at the IPS
+            scenario (``CrashScenarioRow.convexity_pct``).  ``None``
+            renders a labelled empty figure.
+        ips_convexity: Optional IPS convexity target; shades the
+            ``[target_min_pct, target_max_pct]`` band when supplied.
+        ax: Existing Axes to draw on.  Creates a new Figure when
+            ``None``.
+
+    Returns:
+        Matplotlib ``Figure`` (Agg-safe; no ``plt.show()`` called).
+
+    """
+    if ax is None:
+        fig, ax = plt.subplots(figsize=(8, 5))
+    else:
+        maybe_fig = ax.get_figure()
+        if maybe_fig is None:
+            msg = "Supplied ax is not attached to a Figure"
+            raise ValueError(msg)
+        fig = cast(Figure, maybe_fig)
+
+    ax.set_xlabel("Crash Convexity (%)")
+    ax.set_ylabel("Annual Carry Cost ($)")
+    ax.set_title("Carry Cost vs Crash Convexity")
+
+    if carry_cost is None or convexity_pct is None:
+        ax.text(
+            0.5,
+            0.5,
+            "No data",
+            ha="center",
+            va="center",
+            transform=ax.transAxes,
+        )
+        return fig
+
+    if ips_convexity is not None:
+        ax.axvspan(
+            ips_convexity.target_min_pct,
+            ips_convexity.target_max_pct,
+            alpha=0.15,
+            color=DEFAULT_PALETTE.positive,
+            label=(
+                f"IPS target"
+                f" {ips_convexity.target_min_pct:.0f}-"
+                f"{ips_convexity.target_max_pct:.0f}%"
+            ),
+            zorder=1,
+        )
+        ax.axvline(
+            ips_convexity.target_min_pct,
+            color=DEFAULT_PALETTE.positive,
+            linewidth=0.8,
+            linestyle="--",
+            zorder=2,
+        )
+        ax.axvline(
+            ips_convexity.target_max_pct,
+            color=DEFAULT_PALETTE.positive,
+            linewidth=0.8,
+            linestyle="--",
+            zorder=2,
+        )
+
+    ax.axhline(0.0, color="grey", linewidth=0.8, linestyle="-", zorder=0)
+    ax.axvline(0.0, color="grey", linewidth=0.8, linestyle="-", zorder=0)
+
+    ax.scatter(
+        [convexity_pct],
+        [carry_cost],
+        color=DEFAULT_PALETTE.call,
+        s=80,
+        zorder=3,
+        label="Current book",
+    )
+    ax.annotate(
+        f"({convexity_pct:+.1f}%,  ${carry_cost:,.0f}/yr)",
+        xy=(convexity_pct, carry_cost),
+        xytext=(8, 8),
+        textcoords="offset points",
+        fontsize=9,
+        color=DEFAULT_PALETTE.call,
+        zorder=4,
+    )
+
+    ax.xaxis.set_major_formatter(
+        plt.FuncFormatter(lambda v, _: f"{v:+.1f}%"),
+    )
+    ax.yaxis.set_major_formatter(
+        plt.FuncFormatter(lambda v, _: f"${v:,.0f}"),
+    )
+    ax.grid(True, alpha=0.3, zorder=0)
+    ax.legend(fontsize=8)
+
+    return fig
+
+
 class CrashChartsMixin:
-    """Mixin providing crash payoff chart method."""
+    """Mixin providing crash payoff chart methods."""
 
     def plot_crash_convexity(
         self,
@@ -149,3 +267,30 @@ class CrashChartsMixin:
 
         """
         return plot_crash_convexity(result, ax=ax)
+
+    def plot_carry_vs_convexity(
+        self,
+        *,
+        carry_cost: float | None,
+        convexity_pct: float | None,
+        ips_convexity: IpsConvexity | None = None,
+        ax: Axes | None = None,
+    ) -> Figure:
+        """Delegate to module-level ``plot_carry_vs_convexity``.
+
+        Args:
+            carry_cost: Annual carry cost in dollars.
+            convexity_pct: Net crash P&L as % of book notional.
+            ips_convexity: Optional IPS convexity target.
+            ax: Existing Axes to draw on.
+
+        Returns:
+            Matplotlib Figure.
+
+        """
+        return plot_carry_vs_convexity(
+            carry_cost=carry_cost,
+            convexity_pct=convexity_pct,
+            ips_convexity=ips_convexity,
+            ax=ax,
+        )

--- a/deltadewa/widgets/__init__.py
+++ b/deltadewa/widgets/__init__.py
@@ -27,6 +27,7 @@ Usage:
 from deltadewa.widgets.assumptions import GlobalAssumptions
 from deltadewa.widgets.base import InteractiveOutput
 from deltadewa.widgets.convenience import link_portfolio_to_assumptions
+from deltadewa.widgets.env_gauges import build_env_gauges
 from deltadewa.widgets.export_controls import ExportControlsMixin
 from deltadewa.widgets.gauges import GaugeIndicator
 from deltadewa.widgets.health_dashboard import (
@@ -47,5 +48,6 @@ __all__ = [
     "InteractiveOutput",
     "NetHedgeSummary",
     "PortfolioWidgets",
+    "build_env_gauges",
     "link_portfolio_to_assumptions",
 ]

--- a/deltadewa/widgets/env_gauges.py
+++ b/deltadewa/widgets/env_gauges.py
@@ -1,0 +1,216 @@
+"""Market environment gauge widgets for Tier-2 monitoring.
+
+Provides :func:`build_env_gauges`, which renders a pre-computed
+:class:`~deltadewa.analysis.market_environment.MarketEnvironment` as
+three horizontal gauge cards using the same
+:class:`~deltadewa.widgets.gauges.GaugeIndicator` component used by
+:class:`~deltadewa.widgets.health_dashboard.HedgeHealthDashboard`.
+"""
+
+from __future__ import annotations
+
+import ipywidgets as widgets  # type: ignore[import-untyped]
+
+from deltadewa.analysis.market_environment import (
+    DataQuality,
+    MarketEnvironment,
+)
+from deltadewa.colours import DEFAULT_PALETTE
+
+from .gauges import GaugeIndicator
+
+# Breakpoints for 0-100 percentile gauges.
+# Match the vol_regime config in health_dashboard.py (25 / 50 / 75).
+_PCTILE_MIN: float = 25.0
+_PCTILE_MID: float = 50.0
+_PCTILE_MAX: float = 75.0
+
+# Forward vol scale in annualised vol points.
+# 0-12 = low / cheap-hedge contango; 25+ = elevated forward vol.
+_FWD_START: float = 0.0
+_FWD_END: float = 40.0
+_FWD_MIN: float = 12.0
+_FWD_MID: float = 18.0
+_FWD_MAX: float = 25.0
+
+
+def _gauge_inner_html(
+    actual: float,
+    start: float,
+    end: float,
+    min_val: float,
+    mid_val: float,
+    max_val: float,
+    label_format: str,
+    *,
+    invert: bool,
+) -> str:
+    if invert:
+        low_color = DEFAULT_PALETTE.positive
+        high_color = DEFAULT_PALETTE.negative
+    else:
+        low_color = DEFAULT_PALETTE.negative
+        high_color = DEFAULT_PALETTE.positive
+    return (
+        GaugeIndicator(
+            start=start,
+            end=end,
+            min_val=min_val,
+            mid_val=mid_val,
+            max_val=max_val,
+            actual=actual,
+            low_color=low_color,
+            mid_color=DEFAULT_PALETTE.yellow,
+            high_color=high_color,
+            orientation="horizontal",
+            width=280,
+            height=25,
+            show_actual_label=True,
+            show_minmidmax_labels=False,
+            show_startend_labels=True,
+            label_format=label_format,
+            title=None,
+        )
+        .create_widget()
+        .value
+    )
+
+
+def _unavailable_bar() -> str:
+    return (
+        '<div style="'
+        "width:280px;height:25px;background:#e0e0e0;"
+        "border-radius:5px;border:1px solid #ccc;"
+        "display:flex;align-items:center;justify-content:center;"
+        'font-size:14px;color:#999;font-weight:bold;">—</div>'
+    )
+
+
+def _card(title: str, description: str, body_html: str) -> str:
+    return (
+        '<div style="'
+        f"background:{DEFAULT_PALETTE.very_light_grey};"
+        "border-radius:8px;padding:12px;margin:8px;"
+        "min-width:320px;max-width:360px;"
+        'box-shadow:0 2px 4px rgba(0,0,0,0.1);">'
+        '<div style="font-weight:bold;font-size:13px;'
+        f'color:#333;margin-bottom:8px;">{title}</div>'
+        f"{body_html}"
+        '<div style="font-size:10px;color:#666;margin-top:8px;">'
+        f"{description}</div>"
+        "</div>"
+    )
+
+
+def _data_quality_banner(quality: DataQuality) -> str:
+    if quality is DataQuality.STATIC:
+        return (
+            '<div style="font-size:11px;color:#888;'
+            'margin:4px 8px 0 8px;">Static / offline data</div>'
+        )
+    if quality is DataQuality.UNAVAILABLE:
+        return (
+            '<div style="font-size:11px;color:#c00;'
+            'margin:4px 8px 0 8px;">Market data unavailable</div>'
+        )
+    return ""
+
+
+def build_env_gauges(env: MarketEnvironment) -> widgets.HTML:
+    """Render Tier-2 environment gauges from a pre-computed MarketEnvironment.
+
+    Builds three horizontal gauge cards for vol regime percentile, skew
+    percentile, and 1m-3m forward vol, using the same
+    :class:`~deltadewa.widgets.gauges.GaugeIndicator` component as
+    :class:`~deltadewa.widgets.health_dashboard.HedgeHealthDashboard`.
+
+    Must NOT call the market-data provider or
+    :func:`~deltadewa.analysis.market_environment.assess_market_environment`
+    again — consume the pre-computed *env* value object only.
+
+    Degradation:
+        ``LIVE`` — full colour gauges, no footer.
+        ``STATIC`` — full colour gauges with "Static / offline data" caption.
+        ``UNAVAILABLE`` — greyed «—» bars with "Market data unavailable"
+        caption.
+
+    Args:
+        env: Pre-computed ``MarketEnvironment`` snapshot (reuse the
+            ``_env`` variable already computed in the notebook).
+
+    Returns:
+        ``ipywidgets.HTML`` widget ready for ``display()``.
+
+    """
+    unavailable = env.data_quality is DataQuality.UNAVAILABLE
+
+    # --- vol regime percentile (0-100) ---
+    if unavailable or env.regime_percentile is None:
+        regime_body = _unavailable_bar()
+    else:
+        regime_body = _gauge_inner_html(
+            actual=env.regime_percentile,
+            start=0.0,
+            end=100.0,
+            min_val=_PCTILE_MIN,
+            mid_val=_PCTILE_MID,
+            max_val=_PCTILE_MAX,
+            label_format="{:.0f}",
+            invert=True,
+        )
+    regime_card = _card(
+        "Vol Regime Percentile",
+        "VIX historical percentile (0 = low vol, 100 = high vol)",
+        regime_body,
+    )
+
+    # --- skew percentile (provider returns 0-1; display as 0-100) ---
+    if unavailable or env.skew_percentile is None:
+        skew_body = _unavailable_bar()
+    else:
+        skew_body = _gauge_inner_html(
+            actual=env.skew_percentile * 100.0,
+            start=0.0,
+            end=100.0,
+            min_val=_PCTILE_MIN,
+            mid_val=_PCTILE_MID,
+            max_val=_PCTILE_MAX,
+            label_format="{:.0f}",
+            invert=True,
+        )
+    skew_card = _card(
+        "Skew Percentile",
+        "CBOE SKEW rank - higher = more expensive puts",
+        skew_body,
+    )
+
+    # --- forward vol 1m-3m (vol points) ---
+    if unavailable or env.forward_vol_front_3m is None:
+        fwd_body = _unavailable_bar()
+    else:
+        fwd_body = _gauge_inner_html(
+            actual=env.forward_vol_front_3m,
+            start=_FWD_START,
+            end=_FWD_END,
+            min_val=_FWD_MIN,
+            mid_val=_FWD_MID,
+            max_val=_FWD_MAX,
+            label_format="{:.1f}",
+            invert=True,
+        )
+    fwd_card = _card(
+        "Forward Vol 1m-3m",
+        "Implied forward vol between VIX and VIX3M tenors (vol pts)",
+        fwd_body,
+    )
+
+    row = (
+        '<div style="'
+        "font-family:-apple-system,BlinkMacSystemFont,"
+        "'Segoe UI',Roboto,sans-serif;"
+        'display:flex;flex-wrap:wrap;justify-content:flex-start;">'
+        f"{regime_card}{skew_card}{fwd_card}"
+        "</div>"
+    )
+    banner = _data_quality_banner(env.data_quality)
+    return widgets.HTML(value=row + banner)

--- a/monitor_dashboard.ipynb
+++ b/monitor_dashboard.ipynb
@@ -2,6 +2,7 @@
  "cells": [
   {
    "cell_type": "markdown",
+   "id": "0",
    "metadata": {},
    "source": [
     "# Monitor Dashboard — SPX tail hedge\n",
@@ -12,6 +13,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "1",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -43,6 +45,7 @@
     "from deltadewa.marketdata import MarketDataError\n",
     "from deltadewa.reporting import PortfolioChangeTracker\n",
     "from deltadewa.visualization import (\n",
+    "    plot_carry_vs_convexity,\n",
     "    plot_crash_convexity,\n",
     "    plot_greeks_consolidated,\n",
     ")\n",
@@ -50,12 +53,14 @@
     "    HedgeHealthDashboard,\n",
     "    NetHedgeSummary,\n",
     "    PortfolioWidgets,\n",
+    "    build_env_gauges,\n",
     ")"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "2",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -95,6 +100,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "3",
    "metadata": {},
    "source": [
     "## Load portfolio"
@@ -103,6 +109,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "4",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -126,6 +133,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "5",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -137,14 +145,16 @@
   },
   {
    "cell_type": "markdown",
+   "id": "6",
    "metadata": {},
    "source": [
-    "## Market context"
+    "### Market context"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "7",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -161,14 +171,207 @@
   },
   {
    "cell_type": "markdown",
+   "id": "8",
    "metadata": {},
    "source": [
-    "## Market environment"
+    "## Tier 1 — Core Hedge Metrics\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "9",
+   "metadata": {},
+   "source": [
+    "### Net Hedge Summary"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "10",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Hedge Summary\n",
+    "net_hedge_summary = NetHedgeSummary(portfolio)\n",
+    "display(net_hedge_summary.display())"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "11",
+   "metadata": {},
+   "source": [
+    "### Hedge Health"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "12",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Display Hedge Health Dashboard\n",
+    "health_dashboard = HedgeHealthDashboard(portfolio, config=dashboard_config)\n",
+    "dashboard_loader = health_dashboard.display_config_loader()\n",
+    "display(dashboard_loader)\n",
+    "display(health_dashboard.display())\n",
+    "# Update when portfolio changes\n",
+    "health_dashboard.update()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "13",
+   "metadata": {},
+   "source": [
+    "### Crash Payoff & Scenario Table"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "14",
+   "metadata": {},
+   "source": [
+    "### Metric Definitions\n",
+    "\n",
+    "**Crash payoff ratio** = gross hedge payoff in the −X% crash scenario /\n",
+    "premium paid. 8.5x means the hedge returns 8.5x its cost in that crash\n",
+    "(net-profit ratio = payoff ratio − 1). Based on premium paid where\n",
+    "available, else current mark (flagged).\n",
+    "\n",
+    "**Convexity %** — net crash P&L (hedge gain minus the underlying book's\n",
+    "loss at the crash scenario) divided by book notional, as a signed percent.\n",
+    "Positive means the hedge more than covers the equity loss.\n",
+    "The IPS target band sets the acceptable range.\n",
+    "\n",
+    "**Premium Basis** shown in chart annotations: `paid` = cost-basis from position entry prices; `mark (approx)` = today's mark (shown when any long put lacks an `entry_premium`).\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "15",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Compute crash payoff result once — shared by table and chart below.\n",
+    "if portfolio.positions:\n",
+    "    _crash = compute_crash_convexity(\n",
+    "        portfolio,\n",
+    "        ips_convexity=(\n",
+    "            ctx.ips_config.convexity\n",
+    "            if ctx.ips_config is not None\n",
+    "            else None\n",
+    "        ),\n",
+    "    )\n",
+    "else:\n",
+    "    _crash = None\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "16",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Crash Payoff & Scenario Table\n",
+    "if _crash is not None:\n",
+    "    render_crash_table(_crash)\n",
+    "else:\n",
+    "    print(\"No positions in portfolio yet.\")\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "17",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Crash Payoff Chart\n",
+    "if _crash is not None:\n",
+    "    _fig = plot_crash_convexity(_crash)\n",
+    "    plt.show()\n",
+    "    print(\n",
+    "        \"Gross payoff ($) vs shock (%). Dashed line = premium paid; \"\n",
+    "        \"annotation = payoff ratio at IPS crash scenario.\",\n",
+    "    )\n",
+    "else:\n",
+    "    print(\"No positions to chart.\")\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "18",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Carry vs Convexity — cost-vs-protection view\n",
+    "if _crash is not None:\n",
+    "    _carry_metrics = PortfolioAnalyzer(portfolio).calculate_carry_metrics()\n",
+    "    _ips_row = next(\n",
+    "        (\n",
+    "            r for r in _crash.scenario_rows\n",
+    "            if (\n",
+    "                _crash.ips_convexity is not None\n",
+    "                and r.shock_pct == _crash.ips_convexity.crash_scenario_pct\n",
+    "            )\n",
+    "        ),\n",
+    "        None,\n",
+    "    )\n",
+    "    display(plot_carry_vs_convexity(\n",
+    "        carry_cost=_carry_metrics[\"total_theta_annual\"],\n",
+    "        convexity_pct=_ips_row.convexity_pct if _ips_row else None,\n",
+    "        ips_convexity=_crash.ips_convexity,\n",
+    "    ))\n",
+    "else:\n",
+    "    print(\"No positions to chart.\")\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "19",
+   "metadata": {},
+   "source": [
+    "### Cost of Carry"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "20",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Theta Decay & Carry Analysis\n",
+    "carry_display = CarryDisplay(portfolio, reporter)\n",
+    "carry_display.display()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "21",
+   "metadata": {},
+   "source": [
+    "## Tier 2 — Market Environment\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "22",
+   "metadata": {},
+   "source": [
+    "### Market environment"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "23",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -248,181 +451,36 @@
    ]
   },
   {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "## Net Hedge Summary"
-   ]
-  },
-  {
    "cell_type": "code",
    "execution_count": null,
+   "id": "24",
    "metadata": {},
    "outputs": [],
    "source": [
-    "# Hedge Summary\n",
-    "net_hedge_summary = NetHedgeSummary(portfolio)\n",
-    "display(net_hedge_summary.display())"
+    "# Tier-2 environment gauges — renders pre-computed _env\n",
+    "display(build_env_gauges(_env))\n"
    ]
   },
   {
    "cell_type": "markdown",
+   "id": "25",
    "metadata": {},
    "source": [
-    "## Hedge Health"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "# Display Hedge Health Dashboard\n",
-    "health_dashboard = HedgeHealthDashboard(portfolio, config=dashboard_config)\n",
-    "dashboard_loader = health_dashboard.display_config_loader()\n",
-    "display(dashboard_loader)\n",
-    "display(health_dashboard.display())\n",
-    "# Update when portfolio changes\n",
-    "health_dashboard.update()"
+    "## Tier 3 — Structural & Operational\n"
    ]
   },
   {
    "cell_type": "markdown",
+   "id": "26",
    "metadata": {},
    "source": [
-    "## Crash Payoff & Scenario Table"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "### Metric Definitions\n",
-    "\n",
-    "**Crash payoff ratio** = gross hedge payoff in the −X% crash scenario /\n",
-    "premium paid. 8.5x means the hedge returns 8.5x its cost in that crash\n",
-    "(net-profit ratio = payoff ratio − 1). Based on premium paid where\n",
-    "available, else current mark (flagged).\n",
-    "\n",
-    "**Convexity %** — net crash P&L (hedge gain minus the underlying book's\n",
-    "loss at the crash scenario) divided by book notional, as a signed percent.\n",
-    "Positive means the hedge more than covers the equity loss.\n",
-    "The IPS target band sets the acceptable range.\n",
-    "\n",
-    "**Premium Basis** shown in chart annotations: `paid` = cost-basis from position entry prices; `mark (approx)` = today's mark (shown when any long put lacks an `entry_premium`).\n"
+    "### Consolidated Greeks"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "# Compute crash payoff result once — shared by table and chart below.\n",
-    "if portfolio.positions:\n",
-    "    _crash = compute_crash_convexity(\n",
-    "        portfolio,\n",
-    "        ips_convexity=(\n",
-    "            ctx.ips_config.convexity\n",
-    "            if ctx.ips_config is not None\n",
-    "            else None\n",
-    "        ),\n",
-    "    )\n",
-    "else:\n",
-    "    _crash = None\n"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "# Crash Payoff & Scenario Table\n",
-    "if _crash is not None:\n",
-    "    render_crash_table(_crash)\n",
-    "else:\n",
-    "    print(\"No positions in portfolio yet.\")\n"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "# Crash Payoff Chart\n",
-    "if _crash is not None:\n",
-    "    _fig = plot_crash_convexity(_crash)\n",
-    "    plt.show()\n",
-    "    print(\n",
-    "        \"Gross payoff ($) vs shock (%). Dashed line = premium paid; \"\n",
-    "        \"annotation = payoff ratio at IPS crash scenario.\",\n",
-    "    )\n",
-    "else:\n",
-    "    print(\"No positions to chart.\")\n"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "## Roll Status"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "# Display Roll Status\n",
-    "if ips_config is not None:\n",
-    "    try:\n",
-    "        current_spot = market_data.get_spot(portfolio.get_symbol())\n",
-    "    except MarketDataError:\n",
-    "        current_spot = global_assumptions.spot_price.value\n",
-    "    RollStatusDisplay(portfolio, ips_config, reporter=reporter).display(\n",
-    "        current_spot,\n",
-    "    )"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "## Hedge Decision Triggers"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "# Hedge Descision Triggers\n",
-    "trigger_result = evaluate_hedge_triggers(\n",
-    "    portfolio,\n",
-    "    reporter,\n",
-    "    thresholds=(\n",
-    "        HedgeTriggerThresholds.from_ips(ips_config.triggers)\n",
-    "        if ips_config is not None\n",
-    "        else None\n",
-    "    ),\n",
-    ")"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "## Consolidated Greeks"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
+   "id": "27",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -441,32 +499,105 @@
   },
   {
    "cell_type": "markdown",
+   "id": "28",
    "metadata": {},
    "source": [
-    "## Cost of Carry"
+    "### Hedge Decision Triggers"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "29",
    "metadata": {},
    "outputs": [],
    "source": [
-    "# Theta Decay & Carry Analysis\n",
-    "carry_display = CarryDisplay(portfolio, reporter)\n",
-    "carry_display.display()"
+    "# Hedge Descision Triggers\n",
+    "trigger_result = evaluate_hedge_triggers(\n",
+    "    portfolio,\n",
+    "    reporter,\n",
+    "    thresholds=(\n",
+    "        HedgeTriggerThresholds.from_ips(ips_config.triggers)\n",
+    "        if ips_config is not None\n",
+    "        else None\n",
+    "    ),\n",
+    ")"
    ]
   },
   {
    "cell_type": "markdown",
+   "id": "30",
    "metadata": {},
    "source": [
-    "## Position Aging"
+    "### Roll Status"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "31",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Display Roll Status\n",
+    "if ips_config is not None:\n",
+    "    try:\n",
+    "        current_spot = market_data.get_spot(portfolio.get_symbol())\n",
+    "    except MarketDataError:\n",
+    "        current_spot = global_assumptions.spot_price.value\n",
+    "    RollStatusDisplay(portfolio, ips_config, reporter=reporter).display(\n",
+    "        current_spot,\n",
+    "    )"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "32",
+   "metadata": {},
+   "source": [
+    "## Tier 4 — Tactical / Optional\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "33",
+   "metadata": {},
+   "source": [
+    "### Delta Drift Detail\n",
+    "\n",
+    "_Planned — requires net-delta series from position history. See hedge\\_design workbench._\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "34",
+   "metadata": {},
+   "source": [
+    "### Liquidity\n",
+    "\n",
+    "_Planned (Phase D2) — requires a live options-chain feed for bid/ask spread and open-interest data._\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "35",
+   "metadata": {},
+   "source": [
+    "## Positions & Reference\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "36",
+   "metadata": {},
+   "source": [
+    "### Position Aging"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "37",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -476,14 +607,16 @@
   },
   {
    "cell_type": "markdown",
+   "id": "38",
    "metadata": {},
    "source": [
-    "## Position Detail"
+    "### Position Detail"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "39",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -493,14 +626,16 @@
   },
   {
    "cell_type": "markdown",
+   "id": "40",
    "metadata": {},
    "source": [
-    "## Current-book stress snapshot"
+    "### Current-book stress snapshot"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "41",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -519,6 +654,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "42",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -537,14 +673,24 @@
   },
   {
    "cell_type": "markdown",
+   "id": "43",
    "metadata": {},
    "source": [
-    "## Session Change Log"
+    "## Session\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "44",
+   "metadata": {},
+   "source": [
+    "### Session Change Log"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "45",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -554,14 +700,16 @@
   },
   {
    "cell_type": "markdown",
+   "id": "46",
    "metadata": {},
    "source": [
-    "## Export snapshot"
+    "### Export snapshot"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "47",
    "metadata": {},
    "outputs": [],
    "source": [

--- a/monitor_dashboard.ipynb
+++ b/monitor_dashboard.ipynb
@@ -744,5 +744,5 @@
   }
  },
  "nbformat": 4,
- "nbformat_minor": 4
+ "nbformat_minor": 5
 }

--- a/tests/test_visualization/test_crash_charts.py
+++ b/tests/test_visualization/test_crash_charts.py
@@ -157,11 +157,15 @@ class TestPlotCarryVsConvexity:
 
     def test_plotted_point_matches_inputs(self) -> None:
         """Scatter point coordinates match carry_cost and convexity_pct."""
+        import numpy as np
+
         cost, conv = -42_000.0, 7.3
         fig = plot_carry_vs_convexity(carry_cost=cost, convexity_pct=conv)
         try:
             ax = fig.axes[0]
-            offsets = ax.collections[0].get_offsets()
+            offsets: np.ndarray = np.asarray(
+                ax.collections[0].get_offsets(),
+            )
             assert offsets[0][0] == pytest.approx(conv)
             assert offsets[0][1] == pytest.approx(cost)
         finally:

--- a/tests/test_visualization/test_crash_charts.py
+++ b/tests/test_visualization/test_crash_charts.py
@@ -14,7 +14,10 @@ from deltadewa.analysis.crash_payoff import (
 from deltadewa.constants import ExerciseStyle, OptionType
 from deltadewa.ips_config import IpsConvexity
 from deltadewa.portfolio.core import OptionPortfolio
-from deltadewa.visualization.crash_charts import plot_crash_convexity
+from deltadewa.visualization.crash_charts import (
+    plot_carry_vs_convexity,
+    plot_crash_convexity,
+)
 
 matplotlib.use("Agg")
 
@@ -128,6 +131,103 @@ class TestPlotCrashConvexity:
         result = compute_crash_convexity(portfolio)
 
         fig = charts.plot_crash_convexity(result)
+        try:
+            assert len(fig.axes) == 1
+        finally:
+            plt.close(fig)
+
+
+_IPS = IpsConvexity(
+    crash_scenario_pct=-20.0,
+    target_min_pct=5.0,
+    target_max_pct=15.0,
+)
+
+
+class TestPlotCarryVsConvexity:
+    """Tests for plot_carry_vs_convexity."""
+
+    def test_returns_figure_with_one_axes(self) -> None:
+        """Returns a Figure with exactly one Axes."""
+        fig = plot_carry_vs_convexity(carry_cost=-50_000.0, convexity_pct=8.5)
+        try:
+            assert len(fig.axes) == 1
+        finally:
+            plt.close(fig)
+
+    def test_plotted_point_matches_inputs(self) -> None:
+        """Scatter point coordinates match carry_cost and convexity_pct."""
+        cost, conv = -42_000.0, 7.3
+        fig = plot_carry_vs_convexity(carry_cost=cost, convexity_pct=conv)
+        try:
+            ax = fig.axes[0]
+            offsets = ax.collections[0].get_offsets()
+            assert offsets[0][0] == pytest.approx(conv)
+            assert offsets[0][1] == pytest.approx(cost)
+        finally:
+            plt.close(fig)
+
+    def test_none_carry_cost_renders_empty_figure(self) -> None:
+        """None carry_cost produces a labelled empty figure without raising."""
+        fig = plot_carry_vs_convexity(carry_cost=None, convexity_pct=8.5)
+        try:
+            assert len(fig.axes) == 1
+            assert len(fig.axes[0].collections) == 0
+        finally:
+            plt.close(fig)
+
+    def test_none_convexity_pct_renders_empty_figure(self) -> None:
+        """None convexity_pct renders a labelled empty figure."""
+        fig = plot_carry_vs_convexity(carry_cost=-50_000.0, convexity_pct=None)
+        try:
+            assert len(fig.axes) == 1
+            assert len(fig.axes[0].collections) == 0
+        finally:
+            plt.close(fig)
+
+    def test_both_none_renders_empty_figure(self) -> None:
+        """Both None produces a labelled empty figure without raising."""
+        fig = plot_carry_vs_convexity(carry_cost=None, convexity_pct=None)
+        try:
+            assert len(fig.axes) == 1
+        finally:
+            plt.close(fig)
+
+    def test_with_ips_convexity_does_not_raise(self) -> None:
+        """Supplying ips_convexity shades the band without raising."""
+        fig = plot_carry_vs_convexity(
+            carry_cost=-50_000.0,
+            convexity_pct=8.5,
+            ips_convexity=_IPS,
+        )
+        try:
+            assert fig is not None
+        finally:
+            plt.close(fig)
+
+    def test_accepts_existing_axes(self) -> None:
+        """When ax is supplied, returned Figure is the axes' own figure."""
+        fig2, ax2 = plt.subplots()
+        try:
+            returned = plot_carry_vs_convexity(
+                carry_cost=-50_000.0,
+                convexity_pct=8.5,
+                ax=ax2,
+            )
+            assert returned is fig2
+        finally:
+            plt.close(fig2)
+
+    def test_mixin_delegates_to_module_function(self) -> None:
+        """CrashChartsMixin.plot_carry_vs_convexity returns same figure type."""
+        from deltadewa.visualization.base import OptionCharts
+
+        portfolio = _make_long_put_portfolio()
+        charts = OptionCharts(portfolio)
+
+        fig = charts.plot_carry_vs_convexity(
+            carry_cost=-50_000.0, convexity_pct=8.5,
+        )
         try:
             assert len(fig.axes) == 1
         finally:

--- a/tests/test_widgets/test_env_gauges.py
+++ b/tests/test_widgets/test_env_gauges.py
@@ -1,0 +1,137 @@
+"""Tests for deltadewa.widgets.env_gauges."""
+
+import ipywidgets as widgets  # type: ignore[import-untyped]
+
+from deltadewa.analysis.market_environment import (
+    DataQuality,
+    HedgeCostVerdict,
+    MarketEnvironment,
+    RegimeLabel,
+    TermShape,
+)
+from deltadewa.widgets.env_gauges import build_env_gauges
+
+# ruff: noqa: S101
+
+
+def _env(
+    *,
+    quality: DataQuality = DataQuality.LIVE,
+    regime_percentile: float | None = 40.0,
+    skew_percentile: float | None = 0.55,
+    forward_vol_front_3m: float | None = 16.0,
+) -> MarketEnvironment:
+    """Craft a minimal MarketEnvironment for testing."""
+    if quality is DataQuality.UNAVAILABLE:
+        return MarketEnvironment(
+            vix=None,
+            regime_percentile=None,
+            regime_label=None,
+            skew_index=None,
+            skew_percentile=None,
+            term_structure=None,
+            term_shape=None,
+            forward_vol_front_3m=None,
+            hedge_cost_verdict=None,
+            data_quality=DataQuality.UNAVAILABLE,
+        )
+    return MarketEnvironment(
+        vix=18.0,
+        regime_percentile=regime_percentile,
+        regime_label=RegimeLabel.NORMAL,
+        skew_index=130.0,
+        skew_percentile=skew_percentile,
+        term_structure={
+            "VIX9D": 16.0,
+            "VIX": 18.0,
+            "VIX3M": 20.0,
+            "VIX6M": 21.0,
+            "VIX1Y": 22.0,
+        },
+        term_shape=TermShape.CONTANGO,
+        forward_vol_front_3m=forward_vol_front_3m,
+        hedge_cost_verdict=HedgeCostVerdict.FAIR,
+        data_quality=quality,
+    )
+
+
+class TestBuildEnvGauges:
+    """Tests for build_env_gauges."""
+
+    def test_live_returns_html_widget(self) -> None:
+        """LIVE data returns an ipywidgets.HTML instance."""
+        result = build_env_gauges(_env(quality=DataQuality.LIVE))
+        assert isinstance(result, widgets.HTML)
+
+    def test_static_returns_html_widget(self) -> None:
+        """STATIC data returns an ipywidgets.HTML instance."""
+        result = build_env_gauges(_env(quality=DataQuality.STATIC))
+        assert isinstance(result, widgets.HTML)
+
+    def test_unavailable_returns_html_widget(self) -> None:
+        """UNAVAILABLE data returns an ipywidgets.HTML instance."""
+        result = build_env_gauges(_env(quality=DataQuality.UNAVAILABLE))
+        assert isinstance(result, widgets.HTML)
+
+    def test_live_contains_no_quality_banner(self) -> None:
+        """LIVE gauge HTML contains no static/unavailable caption."""
+        html = build_env_gauges(_env(quality=DataQuality.LIVE)).value
+        assert "Static" not in html
+        assert "unavailable" not in html.lower()
+
+    def test_static_shows_caption(self) -> None:
+        """STATIC gauge HTML contains the 'Static / offline data' caption."""
+        html = build_env_gauges(_env(quality=DataQuality.STATIC)).value
+        assert "Static" in html
+
+    def test_unavailable_shows_caption(self) -> None:
+        """UNAVAILABLE gauge HTML contains the 'unavailable' caption."""
+        html = build_env_gauges(_env(quality=DataQuality.UNAVAILABLE)).value
+        assert "unavailable" in html.lower()
+
+    def test_unavailable_shows_dash_placeholder(self) -> None:
+        """UNAVAILABLE gauges show the '—' placeholder bar."""
+        html = build_env_gauges(_env(quality=DataQuality.UNAVAILABLE)).value
+        assert "—" in html
+
+    def test_live_contains_all_three_gauge_titles(self) -> None:
+        """LIVE output contains all three gauge card titles."""
+        html = build_env_gauges(_env(quality=DataQuality.LIVE)).value
+        assert "Vol Regime" in html
+        assert "Skew Percentile" in html
+        assert "Forward Vol" in html
+
+    def test_none_regime_percentile_does_not_raise(self) -> None:
+        """None regime_percentile renders without raising."""
+        result = build_env_gauges(
+            _env(quality=DataQuality.STATIC, regime_percentile=None),
+        )
+        assert isinstance(result, widgets.HTML)
+
+    def test_none_skew_percentile_does_not_raise(self) -> None:
+        """None skew_percentile with STATIC quality renders without raising."""
+        result = build_env_gauges(
+            _env(quality=DataQuality.STATIC, skew_percentile=None),
+        )
+        assert isinstance(result, widgets.HTML)
+
+    def test_none_forward_vol_does_not_raise(self) -> None:
+        """None forward_vol_front_3m renders without raising."""
+        result = build_env_gauges(
+            _env(quality=DataQuality.STATIC, forward_vol_front_3m=None),
+        )
+        assert isinstance(result, widgets.HTML)
+
+    def test_skew_percentile_scaled_to_100(self) -> None:
+        """skew_percentile 0-1 is converted to 0-100 in the output."""
+        html = build_env_gauges(
+            _env(quality=DataQuality.LIVE, skew_percentile=0.72),
+        ).value
+        # GaugeIndicator label_format "{:.0f}" renders 72 (not 0 or 1)
+        assert "72" in html
+
+    def test_exported_from_widgets_package(self) -> None:
+        """build_env_gauges is importable from deltadewa.widgets."""
+        from deltadewa.widgets import build_env_gauges as imported
+
+        assert imported is build_env_gauges


### PR DESCRIPTION
## Summary

Completes the Monitor dashboard's **Part X Tier** structure from the hedging handbook:

- **Tier 1** — Core Hedge Metrics: adds a **Carry vs Convexity** scatter chart (`plot_carry_vs_convexity`) showing annual carry cost against crash-scenario convexity, with IPS target band shaded. Reuses the pre-computed `_crash` object — no repricing.
- **Tier 2** — Market Environment: adds **three environment gauges** (`build_env_gauges`) for vol regime percentile, skew percentile, and forward vol 1m→3m. Renders the pre-computed `_env` object — no second provider call. Degrades to greyed `—` bars under `UNAVAILABLE`; shows "Static / offline data" caption under `STATIC`.
- **`monitor_dashboard.ipynb`** reorganised from a flat 38-cell list into **48 cells** with explicit `## Tier 1–4`, `## Positions & Reference`, and `## Session` headings. Tier-4 has placeholder stubs for Delta Drift Detail and Liquidity (Phase D2 — requires a live options-chain feed).
- **`nbformat_minor`** bumped 4→5 so cell `id` fields pass nbconvert validation cleanly.

## What's left (out of scope here)

- **Tier-4 Liquidity** — Phase D2; requires a live options-chain feed for bid/ask and open-interest data.
- Sizing workbench, strike ladder, monetisation planner — `hedge_design.ipynb` stubs, separate branch.

## Test plan

- [ ] `poetry run pytest` — 764 passed
- [ ] `poetry run mypy .` — no issues in 155 source files
- [ ] `poetry run ruff check .` — all checks passed
- [ ] `poetry run nbqa ruff monitor_dashboard.ipynb` — all checks passed
- [ ] Headless `jupyter nbconvert --execute monitor_dashboard.ipynb` — no cell errors (empty portfolio, StaticProvider)
- [ ] Gauge degradation: `UNAVAILABLE` → `—` bars + "Market data unavailable" caption; `STATIC` → full gauges + "Static / offline data" caption
- [ ] New `tests/test_widgets/test_env_gauges.py` (13 tests) and extended `tests/test_visualization/test_crash_charts.py` (8 new tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)