### PR TITLE
feat: hedge program report — Part VII IC format (closes Phase B)

### DIFF
--- a/deltadewa/reporting/__init__.py
+++ b/deltadewa/reporting/__init__.py
@@ -2,5 +2,19 @@
 
 from deltadewa.reporting.audit import PortfolioChangeTracker, PortfolioLogger
 from deltadewa.reporting.console import ConsoleReporter
+from deltadewa.reporting.program_report import (
+    ProgramReport,
+    build_program_report,
+    render_html,
+    render_markdown,
+)
 
-__all__ = ["ConsoleReporter", "PortfolioChangeTracker", "PortfolioLogger"]
+__all__ = [
+    "ConsoleReporter",
+    "PortfolioChangeTracker",
+    "PortfolioLogger",
+    "ProgramReport",
+    "build_program_report",
+    "render_html",
+    "render_markdown",
+]

--- a/deltadewa/reporting/program_report.py
+++ b/deltadewa/reporting/program_report.py
@@ -1,0 +1,794 @@
+"""Part VII hedge program report — cost, protection, market context, compliance.
+
+Assembles pre-computed crash, carry, and market-environment results into a
+single exportable ``ProgramReport`` and renders it as plain Markdown or a
+self-contained HTML document.  No repricing or recalculation is performed
+here; every figure is drawn from the arguments supplied by the caller.
+"""
+
+from __future__ import annotations
+
+import datetime
+from dataclasses import dataclass
+from html import escape
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from deltadewa.analysis.crash_payoff import CrashConvexityResult
+    from deltadewa.analysis.market_environment import MarketEnvironment
+    from deltadewa.ips_config import IpsConfig
+    from deltadewa.portfolio.core import OptionPortfolio
+
+_MONETIZATION_PLACEHOLDER: str = "n/a — planned (C4)"
+_PENDING_NOTE: str = (
+    "PENDING: start/end book values are not yet tracked; "
+    "before/after-hedge returns cannot be computed."
+)
+
+
+# ── Section dataclasses ───────────────────────────────────────────────────
+
+
+@dataclass(frozen=True)
+class ReportHeader:
+    """Identification block for the report."""
+
+    program_name: str
+    instrument: str
+    period_label: str
+    as_of: datetime.date
+
+
+@dataclass(frozen=True)
+class CostSection:
+    """Annual carry-cost summary and budget compliance.
+
+    Attributes:
+        total_theta_annual: Net annual theta in dollars (negative = cost).
+        book_notional: Protected book notional in dollars.
+        carry_pct_of_notional: ``abs(total_theta_annual) / book_notional``
+            expressed as a percentage.
+        budget_annual_pct: IPS carry budget in percent of notional.
+        within_budget: True when carry_pct_of_notional <=
+            budget_annual_pct.
+
+    """
+
+    total_theta_annual: float
+    book_notional: float
+    carry_pct_of_notional: float
+    budget_annual_pct: float
+    within_budget: bool
+
+
+@dataclass(frozen=True)
+class ProtectionSection:
+    """Crash payoff and IPS convexity-band compliance.
+
+    All fields except ``premium_paid`` and ``premium_basis`` are ``None``
+    when no ``IpsConvexity`` target was supplied to the crash analysis.
+
+    Attributes:
+        payoff_ratio: Gross payoff / premium at the IPS crash point.
+        ips_crash_pct: The signed crash shock used (e.g. -25.0).
+        convexity_pct: Net-of-underlying crash P&L as % of book notional
+            at the IPS shock, from the matching ``CrashScenarioRow``.
+        target_min_pct: IPS lower bound for convexity_pct.
+        target_max_pct: IPS upper bound for convexity_pct.
+        meets_target: True when convexity_pct is within the target band.
+        premium_paid: Total put premium used as the payoff denominator.
+        premium_basis: ``"paid"`` or ``"mark (approx)"``.
+
+    """
+
+    payoff_ratio: float | None
+    ips_crash_pct: float | None
+    convexity_pct: float | None
+    target_min_pct: float | None
+    target_max_pct: float | None
+    meets_target: bool | None
+    premium_paid: float
+    premium_basis: str
+
+
+@dataclass(frozen=True)
+class MarketContextSection:
+    """Regime, skew, and hedge-cost classification snapshot.
+
+    Attributes:
+        vix: Current VIX level in vol points, or ``None``.
+        regime_label: ``"LOW"``, ``"NORMAL"``, or ``"HIGH"``; ``None``
+            when data quality is UNAVAILABLE.
+        skew_percentile: SKEW percentile rank as a 0-1 fraction, or
+            ``None``.
+        hedge_cost_verdict: ``"CHEAP"``, ``"FAIR"``, or ``"EXPENSIVE"``;
+            ``None`` when unavailable.
+        data_quality: ``"LIVE"``, ``"STATIC"``, or ``"UNAVAILABLE"``.
+
+    """
+
+    vix: float | None
+    regime_label: str | None
+    skew_percentile: float | None
+    hedge_cost_verdict: str | None
+    data_quality: str
+
+
+@dataclass(frozen=True)
+class ReturnFramingSection:
+    """Return-attribution framing.
+
+    The carry drag is computed and available; before/after-hedge returns
+    require start/end book values that are not yet tracked and are
+    therefore PENDING.
+
+    Attributes:
+        carry_drag_annual_pct: Annual carry cost as % of book notional
+            (equal to ``CostSection.carry_pct_of_notional``).
+
+    """
+
+    carry_drag_annual_pct: float
+
+
+@dataclass(frozen=True)
+class MonetizationSection:
+    """Monetization realized summary.
+
+    Reported as a separate line item; never netted against carry cost.
+
+    Attributes:
+        realized_label: Human-readable realized-gains status.
+        schedule_steps: Number of ``IpsMonetizationStep`` entries
+            defined in the IPS.
+
+    """
+
+    realized_label: str
+    schedule_steps: int
+
+
+@dataclass(frozen=True)
+class IpsComplianceRow:
+    """One row in the IPS compliance summary table."""
+
+    metric: str
+    target: str
+    actual: str
+    passes: bool
+
+
+@dataclass(frozen=True)
+class IpsComplianceSection:
+    """IPS compliance summary table.
+
+    Attributes:
+        rows: One row per compliance metric.
+        all_pass: True only when every row passes.
+
+    """
+
+    rows: tuple[IpsComplianceRow, ...]
+    all_pass: bool
+
+
+@dataclass(frozen=True)
+class ProgramReport:
+    """Assembled Part VII hedge program report.
+
+    All sections are frozen value objects.  Build with
+    :func:`build_program_report`; render with :func:`render_markdown` or
+    :func:`render_html`.
+    """
+
+    header: ReportHeader
+    cost: CostSection
+    protection: ProtectionSection
+    market_context: MarketContextSection
+    return_framing: ReturnFramingSection
+    monetization: MonetizationSection
+    ips_compliance: IpsComplianceSection
+
+
+# ── Builder ───────────────────────────────────────────────────────────────
+
+
+def build_program_report(
+    *,
+    portfolio: OptionPortfolio,
+    ips_config: IpsConfig,
+    crash_result: CrashConvexityResult,
+    carry_metrics: dict[str, Any],
+    market_env: MarketEnvironment,
+    period_label: str,
+    as_of: datetime.date,
+) -> ProgramReport:
+    """Assemble a ProgramReport from already-computed inputs.
+
+    Does not reprice options, recalculate crash payoffs, or re-assess
+    the market environment — every figure is consumed as supplied.
+    Book notional is derived internally as
+    ``abs(portfolio.underlying_quantity) * portfolio.spot_price``.
+
+    Args:
+        portfolio: The live hedge portfolio.  Used only to derive
+            book notional; no repricing is performed.
+        ips_config: Validated IPS policy.
+        crash_result: Pre-computed from ``compute_crash_convexity``.
+        carry_metrics: Dict from
+            ``PortfolioAnalyzer.calculate_carry_metrics``.
+        market_env: Pre-assessed from ``assess_market_environment``.
+        period_label: Human-readable period (e.g. ``"Q2 2026"``).
+        as_of: Report date.
+
+    Returns:
+        Fully assembled ``ProgramReport``.
+
+    """
+    book_notional = (
+        abs(portfolio.underlying_quantity) * portfolio.spot_price
+    )
+
+    header = ReportHeader(
+        program_name=ips_config.program.name,
+        instrument=ips_config.program.instrument,
+        period_label=period_label,
+        as_of=as_of,
+    )
+
+    cost = _build_cost(
+        carry_metrics=carry_metrics,
+        book_notional=book_notional,
+        budget_annual_pct=ips_config.budget.annual_carry_pct,
+    )
+    protection = _build_protection(crash_result)
+    market_context = _build_market_context(market_env)
+
+    return ProgramReport(
+        header=header,
+        cost=cost,
+        protection=protection,
+        market_context=market_context,
+        return_framing=ReturnFramingSection(
+            carry_drag_annual_pct=cost.carry_pct_of_notional,
+        ),
+        monetization=MonetizationSection(
+            realized_label=_MONETIZATION_PLACEHOLDER,
+            schedule_steps=len(ips_config.monetization.schedule),
+        ),
+        ips_compliance=_build_compliance(cost, protection),
+    )
+
+
+def _build_cost(
+    *,
+    carry_metrics: dict[str, Any],
+    book_notional: float,
+    budget_annual_pct: float,
+) -> CostSection:
+    """Build the CostSection from carry metrics and notional."""
+    theta_annual: float = carry_metrics.get("total_theta_annual", 0.0)
+    carry_pct = (
+        abs(theta_annual) / book_notional * 100
+        if book_notional > 0
+        else 0.0
+    )
+    return CostSection(
+        total_theta_annual=theta_annual,
+        book_notional=book_notional,
+        carry_pct_of_notional=carry_pct,
+        budget_annual_pct=budget_annual_pct,
+        within_budget=carry_pct <= budget_annual_pct,
+    )
+
+
+def _build_protection(
+    crash_result: CrashConvexityResult,
+) -> ProtectionSection:
+    """Build the ProtectionSection from a CrashConvexityResult."""
+    if crash_result.ips_convexity is None:
+        return ProtectionSection(
+            payoff_ratio=crash_result.payoff_ratio,
+            ips_crash_pct=None,
+            convexity_pct=None,
+            target_min_pct=None,
+            target_max_pct=None,
+            meets_target=None,
+            premium_paid=crash_result.premium_paid,
+            premium_basis=crash_result.premium_basis.value,
+        )
+
+    ips_conv = crash_result.ips_convexity
+    ips_shock = ips_conv.crash_scenario_pct
+    matching = next(
+        (
+            r
+            for r in crash_result.scenario_rows
+            if round(r.shock_pct, 4) == round(ips_shock, 4)
+        ),
+        None,
+    )
+    return ProtectionSection(
+        payoff_ratio=crash_result.payoff_ratio,
+        ips_crash_pct=ips_shock,
+        convexity_pct=matching.convexity_pct if matching else None,
+        target_min_pct=ips_conv.target_min_pct,
+        target_max_pct=ips_conv.target_max_pct,
+        meets_target=matching.meets_target if matching else None,
+        premium_paid=crash_result.premium_paid,
+        premium_basis=crash_result.premium_basis.value,
+    )
+
+
+def _build_market_context(
+    market_env: MarketEnvironment,
+) -> MarketContextSection:
+    """Build the MarketContextSection from a MarketEnvironment."""
+    return MarketContextSection(
+        vix=market_env.vix,
+        regime_label=(
+            market_env.regime_label.value
+            if market_env.regime_label is not None
+            else None
+        ),
+        skew_percentile=market_env.skew_percentile,
+        hedge_cost_verdict=(
+            market_env.hedge_cost_verdict.value
+            if market_env.hedge_cost_verdict is not None
+            else None
+        ),
+        data_quality=market_env.data_quality.value,
+    )
+
+
+def _build_compliance(
+    cost: CostSection,
+    protection: ProtectionSection,
+) -> IpsComplianceSection:
+    """Build the IPS compliance table from cost and protection sections."""
+    rows: list[IpsComplianceRow] = [
+        IpsComplianceRow(
+            metric="Annual carry cost",
+            target=f"≤ {cost.budget_annual_pct:.2f}% of notional",
+            actual=f"{cost.carry_pct_of_notional:.2f}%",
+            passes=cost.within_budget,
+        ),
+    ]
+
+    p = protection
+    if (
+        p.ips_crash_pct is not None
+        and p.target_min_pct is not None
+        and p.target_max_pct is not None
+    ):
+        target_str = (
+            f"{p.target_min_pct:.1f}%"
+            f"\u2013{p.target_max_pct:.1f}% of book"
+        )
+        actual_str = (
+            f"{p.convexity_pct:.1f}%"
+            if p.convexity_pct is not None
+            else "—"
+        )
+        rows.append(
+            IpsComplianceRow(
+                metric=(
+                    f"Crash convexity ({p.ips_crash_pct:.0f}% shock)"
+                ),
+                target=target_str,
+                actual=actual_str,
+                passes=bool(p.meets_target),
+            ),
+        )
+    else:
+        rows.append(
+            IpsComplianceRow(
+                metric="Crash convexity",
+                target="—",
+                actual="—",
+                passes=False,
+            ),
+        )
+
+    return IpsComplianceSection(
+        rows=tuple(rows),
+        all_pass=all(r.passes for r in rows),
+    )
+
+
+# ── Formatting helpers (module-private) ───────────────────────────────────
+
+
+def _fmt_money(value: float) -> str:
+    """Format a dollar amount with sign and comma separators."""
+    sign = "-" if value < 0 else ""
+    return f"{sign}${abs(value):,.0f}"
+
+
+def _fmt_pct(value: float | None, decimals: int = 2) -> str:
+    """Format a percentage value, or an em-dash when ``None``."""
+    if value is None:
+        return "—"
+    return f"{value:.{decimals}f}%"
+
+
+def _pass_fail_md(value: bool | None) -> str:
+    """Markdown pass/fail indicator (✓ PASS / ✗ FAIL / —)."""
+    if value is None:
+        return "—"
+    return "✓ PASS" if value else "✗ FAIL"
+
+
+def _pass_fail_html(value: bool | None) -> str:
+    """HTML pass/fail indicator with colour class."""
+    if value is None:
+        return "<span>—</span>"
+    if value:
+        return '<span class="pass">✓ PASS</span>'
+    return '<span class="fail">✗ FAIL</span>'
+
+
+def _html_or_dash(value: str | None) -> str:
+    """HTML-escape a string value, or return an em-dash entity."""
+    return escape(value) if value is not None else "&mdash;"
+
+
+# ── Markdown renderer ─────────────────────────────────────────────────────
+
+
+def render_markdown(report: ProgramReport) -> str:
+    """Render a ProgramReport as a Markdown string.
+
+    Sections follow the Part VII handbook format, separated by horizontal
+    rules.  The IPS compliance block is a Markdown pipe table.  Pass/fail
+    uses ✓/✗ symbols.  A blockquote caveat is injected in the
+    market-context section when data quality is STATIC or UNAVAILABLE.
+
+    Args:
+        report: Assembled report to render.
+
+    Returns:
+        Multi-line Markdown string suitable for display or export.
+
+    """
+    lines: list[str] = []
+
+    # ── Header ──────────────────────────────────────────────────────────
+    h = report.header
+    lines += [
+        "# Part VII: Hedge Program Report",
+        "",
+        f"**Program:** {h.program_name} ({h.instrument})  ",
+        f"**Period:** {h.period_label}  ",
+        f"**As of:** {h.as_of}",
+        "",
+        "---",
+        "",
+    ]
+
+    # ── 1. Cost ─────────────────────────────────────────────────────────
+    c = report.cost
+    lines += [
+        "## 1. Cost",
+        "",
+        "| Metric | Value |",
+        "|--------|-------|",
+        f"| Annual theta (carry cost) | {_fmt_money(c.total_theta_annual)} |",
+        (
+            f"| Carry as % of book notional"
+            f" | {_fmt_pct(c.carry_pct_of_notional)} |"
+        ),
+        f"| IPS budget | ≤ {_fmt_pct(c.budget_annual_pct)} |",
+        f"| Status | {_pass_fail_md(c.within_budget)} |",
+        "",
+    ]
+
+    # ── 2. Protection ───────────────────────────────────────────────────
+    p = report.protection
+    ratio_str = (
+        f"{p.payoff_ratio:.1f}\u00d7"
+        if p.payoff_ratio is not None
+        else "—"
+    )
+    crash_label = (
+        f"{p.ips_crash_pct:.0f}% shock"
+        if p.ips_crash_pct is not None
+        else "n/a (no IPS scenario)"
+    )
+    target_band = (
+        f"{_fmt_pct(p.target_min_pct, 1)}"
+        f"\u2013{_fmt_pct(p.target_max_pct, 1)} of book"
+        if p.target_min_pct is not None
+        else "—"
+    )
+    lines += [
+        "## 2. Protection",
+        "",
+        "| Metric | Value |",
+        "|--------|-------|",
+        (
+            f"| Premium paid"
+            f" | {_fmt_money(p.premium_paid)} ({p.premium_basis}) |"
+        ),
+        f"| IPS crash scenario | {crash_label} |",
+        f"| Payoff ratio at crash | {ratio_str} |",
+        (
+            f"| Convexity (net P&L % of book)"
+            f" | {_fmt_pct(p.convexity_pct, 1)} |"
+        ),
+        f"| IPS convexity target | {target_band} |",
+        f"| Status | {_pass_fail_md(p.meets_target)} |",
+        "",
+    ]
+
+    # ── 3. Market Context ────────────────────────────────────────────────
+    mc = report.market_context
+    lines.append("## 3. Market Context")
+    lines.append("")
+    if mc.data_quality != "LIVE":
+        lines += [
+            (
+                f"> ⚠ Data quality: **{mc.data_quality}**"
+                " — figures are reference values,"
+                " not live market data."
+            ),
+            "",
+        ]
+    vix_str = (
+        f"{mc.vix:.1f}"
+        if mc.vix is not None
+        else "—"
+    )
+    skew_str = (
+        f"{mc.skew_percentile * 100:.1f}%"
+        if mc.skew_percentile is not None
+        else "—"
+    )
+    lines += [
+        "| Metric | Value |",
+        "|--------|-------|",
+        f"| VIX | {vix_str} |",
+        f"| VIX regime | {mc.regime_label or '—'} |",
+        f"| SKEW percentile | {skew_str} |",
+        f"| Hedge-cost verdict | {mc.hedge_cost_verdict or '—'} |",
+        f"| Data quality | {mc.data_quality} |",
+        "",
+    ]
+
+    # ── 4. Return Framing ────────────────────────────────────────────────
+    rf = report.return_framing
+    lines += [
+        "## 4. Return Framing",
+        "",
+        "| | Value |",
+        "|---|-------|",
+        "| Before-hedge return | PENDING |",
+        f"| Annual carry drag | \u2212{_fmt_pct(rf.carry_drag_annual_pct)} |",
+        "| After-hedge return | PENDING |",
+        "",
+        f"> {_PENDING_NOTE}",
+        "",
+    ]
+
+    # ── 5. Monetization Realized ─────────────────────────────────────────
+    m = report.monetization
+    lines += [
+        "## 5. Monetization Realized",
+        "",
+        f"Realized gains: **{m.realized_label}**",
+        "",
+        (
+            "_Monetization is reported separately and never netted against"
+            " carry cost._  "
+        ),
+        f"IPS schedule: {m.schedule_steps} step(s) defined.",
+        "",
+    ]
+
+    # ── 6. IPS Compliance ────────────────────────────────────────────────
+    ic = report.ips_compliance
+    lines += [
+        "## 6. IPS Compliance",
+        "",
+        "| Metric | Target | Actual | Status |",
+        "|--------|--------|--------|--------|",
+    ]
+    for row in ic.rows:
+        lines.append(
+            f"| {row.metric} | {row.target}"
+            f" | {row.actual} | {_pass_fail_md(row.passes)} |",
+        )
+    lines += [
+        "",
+        f"**Overall: {_pass_fail_md(ic.all_pass)}**",
+        "",
+    ]
+
+    return "\n".join(lines)
+
+
+# ── HTML renderer ─────────────────────────────────────────────────────────
+
+_HTML_STYLE = """\
+body {
+  font-family: system-ui, -apple-system, sans-serif;
+  max-width: 820px; margin: 2rem auto; padding: 0 1rem;
+  color: #1a1a1a; line-height: 1.5;
+}
+h1 {
+  font-size: 1.4rem; border-bottom: 2px solid #333;
+  padding-bottom: .4rem; margin-bottom: .5rem;
+}
+h2 {
+  font-size: 1.05rem; border-bottom: 1px solid #ccc;
+  margin-top: 2rem; margin-bottom: .5rem;
+}
+table {
+  border-collapse: collapse; width: 100%;
+  margin: .5rem 0; font-size: .9rem;
+}
+th, td { border: 1px solid #ccc; padding: .35rem .7rem; text-align: left; }
+th { background: #f5f5f5; font-weight: 600; }
+.pass { color: #2a7a2a; font-weight: 600; }
+.fail { color: #cc2222; font-weight: 600; }
+.caveat {
+  background: #fff8e1; border-left: 4px solid #f9a825;
+  padding: .5rem 1rem; margin: .5rem 0; font-size: .9rem;
+}
+.pending { color: #888; font-style: italic; }
+p.note { font-size: .85rem; color: #555; margin-top: .3rem; }"""
+
+
+def render_html(report: ProgramReport) -> str:
+    """Render a ProgramReport as a self-contained HTML document.
+
+    The returned string is a complete ``<!DOCTYPE html>`` page with an
+    inline ``<style>`` block — no external dependencies.  Suitable for
+    saving to a file or displaying in a Jupyter ``IFrame``.
+
+    All user-controlled string values (program name, period label, etc.)
+    are HTML-escaped before insertion.
+
+    Args:
+        report: Assembled report to render.
+
+    Returns:
+        Self-contained HTML string.
+
+    """
+    h = report.header
+    c = report.cost
+    p = report.protection
+    mc = report.market_context
+    rf = report.return_framing
+    m = report.monetization
+    ic = report.ips_compliance
+
+    # ── Pre-compute per-section fragments ──────────────────────────────
+    caveat_html = ""
+    if mc.data_quality != "LIVE":
+        caveat_html = (
+            '<div class="caveat">&#9888;&#160;Data quality:'
+            f" <strong>{escape(mc.data_quality)}</strong>"
+            " &#8212; figures are reference values,"
+            " not live market data.</div>"
+        )
+
+    ratio_str = (
+        f"{p.payoff_ratio:.1f}&times;"
+        if p.payoff_ratio is not None
+        else "&mdash;"
+    )
+    crash_label_html = (
+        f"{p.ips_crash_pct:.0f}% shock"
+        if p.ips_crash_pct is not None
+        else "n/a (no IPS scenario)"
+    )
+    target_band_html = (
+        f"{_fmt_pct(p.target_min_pct, 1)}"
+        f"&ndash;{_fmt_pct(p.target_max_pct, 1)} of book"
+        if p.target_min_pct is not None
+        else "&mdash;"
+    )
+    vix_str = f"{mc.vix:.1f}" if mc.vix is not None else "&mdash;"
+    skew_str = (
+        f"{mc.skew_percentile * 100:.1f}%"
+        if mc.skew_percentile is not None
+        else "&mdash;"
+    )
+
+    compliance_rows_html = "\n".join(
+        f"<tr>"
+        f"<td>{escape(r.metric)}</td>"
+        f"<td>{escape(r.target)}</td>"
+        f"<td>{escape(r.actual)}</td>"
+        f"<td>{_pass_fail_html(r.passes)}</td>"
+        f"</tr>"
+        for r in ic.rows
+    )
+
+    return f"""<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<title>Hedge Program Report &mdash; {escape(h.program_name)}</title>
+<style>
+{_HTML_STYLE}
+</style>
+</head>
+<body>
+
+<h1>Part VII: Hedge Program Report</h1>
+<p>
+  <strong>Program:</strong> {escape(h.program_name)}\
+ ({escape(h.instrument)})<br>
+  <strong>Period:</strong> {escape(h.period_label)}<br>
+  <strong>As of:</strong> {h.as_of}
+</p>
+
+<h2>1. Cost</h2>
+<table>
+<tr><th>Metric</th><th>Value</th></tr>
+<tr><td>Annual theta (carry cost)</td>\
+<td>{escape(_fmt_money(c.total_theta_annual))}</td></tr>
+<tr><td>Carry as % of book notional</td>\
+<td>{escape(_fmt_pct(c.carry_pct_of_notional))}</td></tr>
+<tr><td>IPS budget</td>\
+<td>&le;&#160;{escape(_fmt_pct(c.budget_annual_pct))}</td></tr>
+<tr><td>Status</td><td>{_pass_fail_html(c.within_budget)}</td></tr>
+</table>
+
+<h2>2. Protection</h2>
+<table>
+<tr><th>Metric</th><th>Value</th></tr>
+<tr><td>Premium paid</td>\
+<td>{escape(_fmt_money(p.premium_paid))} ({escape(p.premium_basis)})</td></tr>
+<tr><td>IPS crash scenario</td><td>{escape(crash_label_html)}</td></tr>
+<tr><td>Payoff ratio at crash</td><td>{ratio_str}</td></tr>
+<tr><td>Convexity (net P&amp;L % of book)</td>\
+<td>{escape(_fmt_pct(p.convexity_pct, 1))}</td></tr>
+<tr><td>IPS convexity target</td><td>{target_band_html}</td></tr>
+<tr><td>Status</td><td>{_pass_fail_html(p.meets_target)}</td></tr>
+</table>
+
+<h2>3. Market Context</h2>
+{caveat_html}
+<table>
+<tr><th>Metric</th><th>Value</th></tr>
+<tr><td>VIX</td><td>{vix_str}</td></tr>
+<tr><td>VIX regime</td><td>{_html_or_dash(mc.regime_label)}</td></tr>
+<tr><td>SKEW percentile</td><td>{skew_str}</td></tr>
+<tr><td>Hedge-cost verdict</td>\
+<td>{_html_or_dash(mc.hedge_cost_verdict)}</td></tr>
+<tr><td>Data quality</td><td>{escape(mc.data_quality)}</td></tr>
+</table>
+
+<h2>4. Return Framing</h2>
+<table>
+<tr><th></th><th>Value</th></tr>
+<tr><td>Before-hedge return</td>\
+<td class="pending">PENDING</td></tr>
+<tr><td>Annual carry drag</td>\
+<td>&minus;{escape(_fmt_pct(rf.carry_drag_annual_pct))}</td></tr>
+<tr><td>After-hedge return</td>\
+<td class="pending">PENDING</td></tr>
+</table>
+<p class="note">{escape(_PENDING_NOTE)}</p>
+
+<h2>5. Monetization Realized</h2>
+<p>Realized gains: <strong>{escape(m.realized_label)}</strong></p>
+<p class="note">
+  Monetization is reported separately and never netted against carry\
+ cost.<br>
+  IPS schedule: {m.schedule_steps} step(s) defined.
+</p>
+
+<h2>6. IPS Compliance</h2>
+<table>
+<tr><th>Metric</th><th>Target</th><th>Actual</th><th>Status</th></tr>
+{compliance_rows_html}
+</table>
+<p><strong>Overall: {_pass_fail_html(ic.all_pass)}</strong></p>
+
+</body>
+</html>"""

--- a/monitor_dashboard.ipynb
+++ b/monitor_dashboard.ipynb
@@ -43,7 +43,11 @@
     "    start_session,\n",
     ")\n",
     "from deltadewa.marketdata import MarketDataError\n",
-    "from deltadewa.reporting import PortfolioChangeTracker\n",
+    "from deltadewa.reporting import (\n",
+    "    PortfolioChangeTracker,\n",
+    "    build_program_report,\n",
+    "    render_html,\n",
+    ")\n",
     "from deltadewa.visualization import (\n",
     "    plot_carry_vs_convexity,\n",
     "    plot_crash_convexity,\n",
@@ -583,12 +587,71 @@
    "id": "35",
    "metadata": {},
    "source": [
+    "## Part VII — Hedge Program Report\n",
+    "\n",
+    "Assembles the pre-computed crash, carry, and market-environment results into a\n",
+    "single printable summary aligned with IPS Part VII.\n",
+    "Edit `_period_label` before running, then run the cell."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "36",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "_period_label = \"Q2 2026\"  # <- edit before running\n",
+    "\n",
+    "if not portfolio.positions:\n",
+    "    print(\"Program Report: load a portfolio first.\")\n",
+    "elif ips_config is None:\n",
+    "    print(\"Program Report: IPS config unavailable (check ips.yaml).\")\n",
+    "else:\n",
+    "    _rpt_carry = (\n",
+    "        _carry_metrics\n",
+    "        if \"_carry_metrics\" in vars()\n",
+    "        else PortfolioAnalyzer(portfolio).calculate_carry_metrics()\n",
+    "    )\n",
+    "    _report = build_program_report(\n",
+    "        portfolio=portfolio,\n",
+    "        ips_config=ips_config,\n",
+    "        crash_result=_crash,\n",
+    "        carry_metrics=_rpt_carry,\n",
+    "        market_env=_env,\n",
+    "        period_label=_period_label,\n",
+    "        as_of=today,\n",
+    "    )\n",
+    "    _html = render_html(_report)\n",
+    "    display(HTML(_html))\n",
+    "    _report_path = EXPORT_DIR / f\"program_report_{today}.html\"\n",
+    "    _report_path.parent.mkdir(parents=True, exist_ok=True)\n",
+    "    _report_path.write_text(_html, encoding=\"utf-8\")\n",
+    "    print(f\"Saved: {_report_path}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "37",
+   "metadata": {},
+   "source": [
+    "> **Phase-D follow-on:** this notebook can be run headless via\n",
+    "> [papermill](https://papermill.readthedocs.io/) by tagging `_period_label`\n",
+    "> (and optionally a `portfolio_path` parameter cell) — enabling scheduled,\n",
+    "> no-UI report generation. Not part of this branch."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "38",
+   "metadata": {},
+   "source": [
     "## Positions & Reference\n"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "36",
+   "id": "39",
    "metadata": {},
    "source": [
     "### Position Aging"
@@ -597,7 +660,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "37",
+   "id": "40",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -607,7 +670,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "38",
+   "id": "41",
    "metadata": {},
    "source": [
     "### Position Detail"
@@ -616,7 +679,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "39",
+   "id": "42",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -626,7 +689,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "40",
+   "id": "43",
    "metadata": {},
    "source": [
     "### Current-book stress snapshot"
@@ -635,7 +698,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "41",
+   "id": "44",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -654,7 +717,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "42",
+   "id": "45",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -673,7 +736,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "43",
+   "id": "46",
    "metadata": {},
    "source": [
     "## Session\n"
@@ -681,7 +744,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "44",
+   "id": "47",
    "metadata": {},
    "source": [
     "### Session Change Log"
@@ -690,7 +753,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "45",
+   "id": "48",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -700,7 +763,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "46",
+   "id": "49",
    "metadata": {},
    "source": [
     "### Export snapshot"
@@ -709,7 +772,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "47",
+   "id": "50",
    "metadata": {},
    "outputs": [],
    "source": [

--- a/tests/test_reporting/__init__.py
+++ b/tests/test_reporting/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for deltadewa.reporting."""

--- a/tests/test_reporting/test_program_report.py
+++ b/tests/test_reporting/test_program_report.py
@@ -1,0 +1,503 @@
+"""Tests for deltadewa.reporting.program_report."""
+
+# ruff: noqa: S101
+
+import datetime
+
+import pytest
+
+from deltadewa.analysis.crash_payoff import (
+    CrashConvexityResult,
+    CrashScenarioRow,
+    PremiumBasis,
+)
+from deltadewa.analysis.market_environment import (
+    DataQuality,
+    HedgeCostVerdict,
+    MarketEnvironment,
+    RegimeLabel,
+    TermShape,
+)
+from deltadewa.constants import ExerciseStyle
+from deltadewa.ips_config import (
+    IpsBudget,
+    IpsConfig,
+    IpsConvexity,
+    IpsDrawdown,
+    IpsMonetization,
+    IpsMonetizationStep,
+    IpsPricing,
+    IpsProgram,
+    IpsTriggers,
+)
+from deltadewa.portfolio.core import OptionPortfolio
+from deltadewa.reporting.program_report import (
+    ProgramReport,
+    build_program_report,
+    render_html,
+    render_markdown,
+)
+
+# ── Fixtures / helpers ────────────────────────────────────────────────────
+
+_AS_OF = datetime.date(2026, 6, 24)
+_IPS_CONVEXITY = IpsConvexity(
+    crash_scenario_pct=-25.0,
+    target_min_pct=10.0,
+    target_max_pct=30.0,
+)
+
+
+def _make_ips_config(
+    annual_carry_pct: float = 2.0,
+    schedule_steps: int = 2,
+) -> IpsConfig:
+    steps = tuple(
+        IpsMonetizationStep(gain_pct=float(i + 1) * 100, sell_pct=50.0)
+        for i in range(schedule_steps)
+    )
+    return IpsConfig(
+        program=IpsProgram(name="SPX Tail Hedge", instrument="SPX"),
+        pricing=IpsPricing(exercise_style=ExerciseStyle.EUROPEAN),
+        budget=IpsBudget(annual_carry_pct=annual_carry_pct),
+        convexity=_IPS_CONVEXITY,
+        drawdown=IpsDrawdown(max_tolerance_pct=5.0),
+        triggers=IpsTriggers(
+            delta_drift_warn_pct=5.0,
+            delta_drift_action_pct=10.0,
+            theta_cost_acceptable_pct=2.0,
+            roll_time_months=2.0,
+            rally_rebalance_pct=5.0,
+            strike_drift_max_otm_pct=10.0,
+        ),
+        monetization=IpsMonetization(schedule=steps),
+    )
+
+
+def _make_crash_result(
+    *,
+    ips_convexity: IpsConvexity | None = _IPS_CONVEXITY,
+    payoff_ratio: float | None = 8.5,
+    convexity_pct: float = 15.0,
+    meets_target: bool = True,
+    premium_paid: float = 10_000.0,
+) -> CrashConvexityResult:
+    rows = []
+    if ips_convexity is not None:
+        rows.append(
+            CrashScenarioRow(
+                shock_pct=ips_convexity.crash_scenario_pct,
+                hedge_pnl=premium_paid * (payoff_ratio or 0),
+                payoff_ratio=payoff_ratio or 0.0,
+                convexity_pct=convexity_pct,
+                meets_target=meets_target,
+            ),
+        )
+    return CrashConvexityResult(
+        curve=[],
+        scenario_rows=rows,
+        payoff_ratio=payoff_ratio,
+        premium_paid=premium_paid,
+        premium_basis=PremiumBasis.PAID,
+        ips_convexity=ips_convexity,
+    )
+
+
+def _make_market_env(
+    data_quality: DataQuality = DataQuality.LIVE,
+) -> MarketEnvironment:
+    if data_quality is DataQuality.UNAVAILABLE:
+        return MarketEnvironment(
+            vix=None,
+            regime_percentile=None,
+            regime_label=None,
+            skew_index=None,
+            skew_percentile=None,
+            term_structure=None,
+            term_shape=None,
+            forward_vol_front_3m=None,
+            hedge_cost_verdict=None,
+            data_quality=DataQuality.UNAVAILABLE,
+        )
+    return MarketEnvironment(
+        vix=18.0,
+        regime_percentile=30.0,
+        regime_label=RegimeLabel.NORMAL,
+        skew_index=130.0,
+        skew_percentile=0.45,
+        term_structure={
+            "VIX": 18.0,
+            "VIX3M": 19.0,
+            "VIX6M": 20.0,
+            "VIX1Y": 21.0,
+        },
+        term_shape=TermShape.CONTANGO,
+        forward_vol_front_3m=20.0,
+        hedge_cost_verdict=HedgeCostVerdict.FAIR,
+        data_quality=data_quality,
+    )
+
+
+def _make_carry_metrics(theta_annual: float = -8_000.0) -> dict:
+    return {"total_theta_annual": theta_annual}
+
+
+def _make_portfolio(
+    underlying_quantity: float = 100.0,
+    spot_price: float = 5_000.0,
+) -> OptionPortfolio:
+    return OptionPortfolio(
+        underlying_quantity=underlying_quantity,
+        spot_price=spot_price,
+    )
+
+
+def _build(
+    *,
+    theta_annual: float = -8_000.0,
+    budget_pct: float = 2.0,
+    underlying_quantity: float = 100.0,
+    spot_price: float = 5_000.0,
+    ips_convexity: IpsConvexity | None = _IPS_CONVEXITY,
+    payoff_ratio: float | None = 8.5,
+    convexity_pct: float = 15.0,
+    meets_target: bool = True,
+    data_quality: DataQuality = DataQuality.LIVE,
+    schedule_steps: int = 2,
+) -> ProgramReport:
+    return build_program_report(
+        portfolio=_make_portfolio(
+            underlying_quantity=underlying_quantity,
+            spot_price=spot_price,
+        ),
+        ips_config=_make_ips_config(
+            annual_carry_pct=budget_pct,
+            schedule_steps=schedule_steps,
+        ),
+        crash_result=_make_crash_result(
+            ips_convexity=ips_convexity,
+            payoff_ratio=payoff_ratio,
+            convexity_pct=convexity_pct,
+            meets_target=meets_target,
+        ),
+        carry_metrics=_make_carry_metrics(theta_annual),
+        market_env=_make_market_env(data_quality),
+        period_label="Q2 2026",
+        as_of=_AS_OF,
+    )
+
+
+# ── build_program_report ──────────────────────────────────────────────────
+
+
+class TestBuildProgramReport:
+    """Tests for build_program_report."""
+
+    def test_header_fields(self) -> None:
+        """Header is populated from IPS config and call arguments."""
+        report = _build()
+        h = report.header
+        assert h.program_name == "SPX Tail Hedge"
+        assert h.instrument == "SPX"
+        assert h.period_label == "Q2 2026"
+        assert h.as_of == _AS_OF
+
+    def test_cost_within_budget(self) -> None:
+        """carry_pct <= budget → within_budget True."""
+        # notional = 100 * 5000 = 500_000; carry = 8000/500000*100 = 1.6%
+        report = _build(theta_annual=-8_000.0, budget_pct=2.0)
+        assert report.cost.carry_pct_of_notional == pytest.approx(1.6)
+        assert report.cost.within_budget is True
+
+    def test_cost_over_budget(self) -> None:
+        """carry_pct > budget → within_budget False."""
+        report = _build(theta_annual=-15_000.0, budget_pct=2.0)
+        # 15000/500000*100 = 3%
+        assert report.cost.carry_pct_of_notional == pytest.approx(3.0)
+        assert report.cost.within_budget is False
+
+    def test_cost_exactly_at_budget(self) -> None:
+        """carry_pct == budget exactly → within_budget True."""
+        # 10_000 / 500_000 * 100 = 2.0%
+        report = _build(theta_annual=-10_000.0, budget_pct=2.0)
+        assert report.cost.within_budget is True
+
+    def test_cost_book_notional(self) -> None:
+        """book_notional derives from underlying_quantity * spot_price."""
+        report = _build(underlying_quantity=200.0, spot_price=3_000.0)
+        assert report.cost.book_notional == pytest.approx(600_000.0)
+
+    def test_protection_row_matched(self) -> None:
+        """IPS crash_pct matches a scenario_row → fields populated."""
+        report = _build(convexity_pct=18.0, meets_target=True)
+        p = report.protection
+        assert p.ips_crash_pct == pytest.approx(-25.0)
+        assert p.convexity_pct == pytest.approx(18.0)
+        assert p.meets_target is True
+        assert p.payoff_ratio == pytest.approx(8.5)
+        assert p.target_min_pct == pytest.approx(10.0)
+        assert p.target_max_pct == pytest.approx(30.0)
+
+    def test_protection_row_not_meeting_target(self) -> None:
+        """meets_target False when convexity below band."""
+        report = _build(convexity_pct=5.0, meets_target=False)
+        assert report.protection.meets_target is False
+
+    def test_protection_no_ips_convexity(self) -> None:
+        """All optional protection fields are None when no IPS scenario."""
+        report = _build(ips_convexity=None, payoff_ratio=None)
+        p = report.protection
+        assert p.ips_crash_pct is None
+        assert p.convexity_pct is None
+        assert p.target_min_pct is None
+        assert p.target_max_pct is None
+        assert p.meets_target is None
+
+    def test_market_context_live(self) -> None:
+        """LIVE quality → all fields populated."""
+        report = _build(data_quality=DataQuality.LIVE)
+        mc = report.market_context
+        assert mc.data_quality == "LIVE"
+        assert mc.vix == pytest.approx(18.0)
+        assert mc.regime_label == "NORMAL"
+        assert mc.skew_percentile == pytest.approx(0.45)
+        assert mc.hedge_cost_verdict == "FAIR"
+
+    def test_market_context_static(self) -> None:
+        """STATIC quality surfaced in data_quality field."""
+        report = _build(data_quality=DataQuality.STATIC)
+        assert report.market_context.data_quality == "STATIC"
+
+    def test_market_context_unavailable(self) -> None:
+        """UNAVAILABLE → regime/skew/verdict all None."""
+        report = _build(data_quality=DataQuality.UNAVAILABLE)
+        mc = report.market_context
+        assert mc.data_quality == "UNAVAILABLE"
+        assert mc.vix is None
+        assert mc.regime_label is None
+        assert mc.skew_percentile is None
+        assert mc.hedge_cost_verdict is None
+
+    def test_return_framing_carry_drag(self) -> None:
+        """carry_drag_annual_pct mirrors cost.carry_pct_of_notional."""
+        report = _build(theta_annual=-8_000.0)
+        assert report.return_framing.carry_drag_annual_pct == pytest.approx(
+            report.cost.carry_pct_of_notional,
+        )
+
+    def test_monetization_label_is_placeholder(self) -> None:
+        """realized_label is always the placeholder string."""
+        report = _build()
+        assert "planned" in report.monetization.realized_label
+        assert "C4" in report.monetization.realized_label
+
+    def test_monetization_schedule_steps(self) -> None:
+        """schedule_steps reflects the IPS monetization schedule length."""
+        report = _build(schedule_steps=3)
+        assert report.monetization.schedule_steps == 3
+
+    def test_monetization_separate_from_carry(self) -> None:
+        """Monetization realized_label is never derived from cost fields."""
+        report = _build()
+        assert report.monetization.realized_label != str(
+            report.cost.total_theta_annual,
+        )
+        assert report.monetization.realized_label != str(
+            report.cost.carry_pct_of_notional,
+        )
+
+    def test_ips_compliance_all_pass(self) -> None:
+        """all_pass True when both carry and convexity pass."""
+        report = _build(
+            theta_annual=-8_000.0,
+            budget_pct=2.0,
+            convexity_pct=15.0,
+            meets_target=True,
+        )
+        assert report.ips_compliance.all_pass is True
+
+    def test_ips_compliance_carry_fail(self) -> None:
+        """all_pass False when carry exceeds budget."""
+        report = _build(
+            theta_annual=-20_000.0,
+            budget_pct=2.0,
+            meets_target=True,
+        )
+        assert report.ips_compliance.all_pass is False
+
+    def test_ips_compliance_convexity_fail(self) -> None:
+        """all_pass False when convexity misses the band."""
+        report = _build(
+            theta_annual=-8_000.0,
+            budget_pct=2.0,
+            meets_target=False,
+        )
+        assert report.ips_compliance.all_pass is False
+
+    def test_ips_compliance_row_count(self) -> None:
+        """Exactly two compliance rows: carry and convexity."""
+        report = _build()
+        assert len(report.ips_compliance.rows) == 2
+
+
+# ── render_markdown ───────────────────────────────────────────────────────
+
+
+def _make_full_report() -> ProgramReport:
+    return _build()
+
+
+class TestRenderMarkdown:
+    """Tests for render_markdown."""
+
+    def test_returns_string(self) -> None:
+        """render_markdown returns a str."""
+        md = render_markdown(_make_full_report())
+        assert isinstance(md, str)
+
+    def test_section_headers_present(self) -> None:
+        """All six numbered section headers are present."""
+        md = render_markdown(_make_full_report())
+        for heading in (
+            "## 1. Cost",
+            "## 2. Protection",
+            "## 3. Market Context",
+            "## 4. Return Framing",
+            "## 5. Monetization Realized",
+            "## 6. IPS Compliance",
+        ):
+            assert heading in md, f"missing: {heading!r}"
+
+    def test_pass_symbols_present(self) -> None:
+        """✓ PASS and ✗ appear somewhere in the output."""
+        md_pass = render_markdown(
+            _build(theta_annual=-8_000.0, meets_target=True),
+        )
+        assert "✓ PASS" in md_pass
+
+        md_fail = render_markdown(
+            _build(theta_annual=-20_000.0, meets_target=False),
+        )
+        assert "✗ FAIL" in md_fail
+
+    def test_pending_return_note_present(self) -> None:
+        """PENDING label appears in the return framing section."""
+        md = render_markdown(_make_full_report())
+        assert "PENDING" in md
+
+    def test_static_caveat_present_when_static(self) -> None:
+        """Data-quality caveat appears for STATIC data."""
+        md = render_markdown(_build(data_quality=DataQuality.STATIC))
+        assert "STATIC" in md
+        assert "reference values" in md
+
+    def test_caveat_absent_when_live(self) -> None:
+        """No caveat injected for LIVE data."""
+        md = render_markdown(_build(data_quality=DataQuality.LIVE))
+        assert "reference values" not in md
+
+    def test_monetization_placeholder_present(self) -> None:
+        """The monetization placeholder string appears in the output."""
+        md = render_markdown(_make_full_report())
+        assert "planned (C4)" in md
+
+    def test_key_figures_in_output(self) -> None:
+        """Cost % and budget % appear numerically in the output."""
+        report = _build(theta_annual=-8_000.0, budget_pct=2.0)
+        md = render_markdown(report)
+        # 1.60% carry; budget ≤ 2.00%
+        assert "1.60%" in md
+        assert "2.00%" in md
+
+    def test_ips_compliance_table_row_count(self) -> None:
+        """Compliance pipe-table has two data rows (header + separator + 2)."""
+        md = render_markdown(_make_full_report())
+        # Count lines that look like table rows with 4 pipes
+        table_rows = [
+            ln
+            for ln in md.splitlines()
+            if ln.startswith("|") and ln.count("|") >= 5
+        ]
+        # header row + 2 data rows = 3
+        assert len(table_rows) >= 2
+
+
+# ── render_html ───────────────────────────────────────────────────────────
+
+
+class TestRenderHtml:
+    """Tests for render_html."""
+
+    def test_returns_string(self) -> None:
+        """render_html returns a str."""
+        html = render_html(_make_full_report())
+        assert isinstance(html, str)
+
+    def test_doctype_present(self) -> None:
+        """Output starts with <!DOCTYPE html>."""
+        html = render_html(_make_full_report())
+        assert html.startswith("<!DOCTYPE html>")
+
+    def test_section_headings_present(self) -> None:
+        """All six <h2> section headings appear in the HTML."""
+        html = render_html(_make_full_report())
+        for heading in (
+            "1. Cost",
+            "2. Protection",
+            "3. Market Context",
+            "4. Return Framing",
+            "5. Monetization Realized",
+            "6. IPS Compliance",
+        ):
+            assert heading in html, f"missing heading: {heading!r}"
+
+    def test_compliance_table_present(self) -> None:
+        """The compliance table tag is present."""
+        html = render_html(_make_full_report())
+        assert "<table>" in html
+
+    def test_pending_label_present(self) -> None:
+        """PENDING label appears in the return-framing section."""
+        html = render_html(_make_full_report())
+        assert "PENDING" in html
+
+    def test_monetization_placeholder_present(self) -> None:
+        """Monetization placeholder string is in the HTML."""
+        html = render_html(_make_full_report())
+        assert "planned (C4)" in html
+
+    def test_data_quality_caveat_static(self) -> None:
+        """Caveat div appears for STATIC data."""
+        html = render_html(_build(data_quality=DataQuality.STATIC))
+        assert 'class="caveat"' in html
+        assert "STATIC" in html
+
+    def test_data_quality_caveat_absent_live(self) -> None:
+        """No caveat div for LIVE data."""
+        html = render_html(_build(data_quality=DataQuality.LIVE))
+        assert 'class="caveat"' not in html
+
+    def test_pass_class_present(self) -> None:
+        """HTML class 'pass' appears for passing metrics."""
+        html = render_html(
+            _build(theta_annual=-8_000.0, meets_target=True),
+        )
+        assert 'class="pass"' in html
+
+    def test_fail_class_present(self) -> None:
+        """HTML class 'fail' appears for failing metrics."""
+        html = render_html(
+            _build(theta_annual=-20_000.0, meets_target=False),
+        )
+        assert 'class="fail"' in html
+
+    def test_inline_style_block(self) -> None:
+        """Output contains an inline <style> block."""
+        html = render_html(_make_full_report())
+        assert "<style>" in html
+
+    def test_no_external_dependencies(self) -> None:
+        """No link rel=stylesheet or script src in the output."""
+        html = render_html(_make_full_report())
+        assert 'rel="stylesheet"' not in html
+        assert "<script" not in html


### PR DESCRIPTION
## Summary

- **New module** `deltadewa/reporting/program_report.py` — 8 frozen section dataclasses, a pure-assembly `build_program_report()` builder, and two renderers (`render_markdown`, `render_html`).
- **No repricing** — builder consumes pre-computed `crash_result`, `carry_metrics`, and `market_env` exactly as passed; `book_notional` derived from `portfolio.underlying_quantity × portfolio.spot_price` internally.
- **IPS compliance flags** (within-budget, meets-target) derived from `ips_config` at build time.
- **Return section labelled PENDING** — "PENDING: start/end book values are not yet tracked; before/after-hedge returns cannot be computed." No return numbers fabricated.
- **Monetization as a separate placeholder** — `"n/a — planned (C4)"`, never netted against carry cost.
- **Self-contained HTML renderer** — `<!DOCTYPE html>` with inline `<style>`, no external dependencies; suitable for saving and printing.
- **Notebook wiring** — `## Part VII — Hedge Program Report` section added to `monitor_dashboard.ipynb` after Tier 4, with empty-portfolio and no-IPS guards; writes `export_dir/program_report_<date>.html` and prints the saved path.
- **40 new tests** in `tests/test_reporting/test_program_report.py`.

## Gate

| Check | Result |
|-------|--------|
| `poetry run pytest` | 807 passed |
| `poetry run mypy .` | no issues in 158 files |
| `poetry run ruff check .` | clean |
| `poetry run nbqa ruff monitor_dashboard.ipynb` | clean |
| Headless `nbconvert --execute` (empty portfolio) | guard note printed, no exception |

## This closes Phase B

Monitor dashboard is now fully handbook-aligned: **Tiers 1–4** (crash payoff, carry/convexity, market environment, triggers/roll) **+ Part VII program report** (cost, protection, market context, return framing, monetization, IPS compliance).

## Known follow-ons (not part of this branch)

- **Period return P&L history** — `ReturnFramingSection.carry_drag_annual_pct` is populated; before/after-hedge returns require a start/end book-value tracking mechanism (Phase C or D).
- **Monetization realized** — placeholder `"n/a — planned (C4)"` will be replaced when monetization-event logging is implemented (Phase C4).
- **Headless papermill execution** — a `_period_label` parameter cell can be tagged for scheduled report generation; noted in the notebook as a Phase-D follow-on.

## Test plan

- [ ] Load a portfolio in `monitor_dashboard.ipynb`, run through Tier 1–2 cells, then run the Part VII cell — verify HTML renders inline and `exports/program_report_<date>.html` is written.
- [ ] Run with an empty portfolio — confirm guard note printed, no traceback.
- [ ] Run with `ips_config=None` (remove/rename `ips.yaml`) — confirm IPS note printed.
- [ ] Open the exported HTML in a browser and verify all 6 sections are present, PENDING rows are clearly labelled, and the IPS compliance table shows the correct pass/fail status.

🤖 Generated with [Claude Code](https://claude.com/claude-code)