### PR TITLE
chore: integrate pylint — config, triage, green baseline

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -21,11 +21,13 @@ Python `>=3.11,<4.0`, managed with **Poetry**. Run everything through `poetry ru
 - Tests: `poetry run pytest`
 - Type-check: `poetry run mypy .` (custom stubs live in `typings/`; `pandas-stubs` is installed)
 - Lint: `poetry run ruff check .`
+- Design/refactor smells: `poetry run pylint deltadewa` — covers duplicate-code, cyclic-import, and
+  complexity limits; `tests/` and notebooks are intentionally out of scope for now
 - Format: `poetry run black .` (or `poetry run ruff format .`) — **line length is 80**
 - Lint/type-check notebooks: `poetry run nbqa ruff <notebook>` / `poetry run nbqa mypy <notebook>`
 
 Before considering any change done: `poetry run pytest` and `poetry run mypy .` must both be green,
-and `poetry run ruff check .` must be clean.
+`poetry run ruff check .` must be clean, and `poetry run pylint deltadewa` must exit 0.
 
 ## Architecture (keep UI thin)
 

--- a/deltadewa/analysis/base.py
+++ b/deltadewa/analysis/base.py
@@ -36,7 +36,7 @@ class PortfolioAnalyzerBase:
         self.portfolio = portfolio
 
 
-class PortfolioAnalyzer(
+class PortfolioAnalyzer(  # pylint: disable=too-many-ancestors  # mixin architecture; each mixin is a separate concern
     MaturityMixin,
     CarryMixin,
     RecommendationsMixin,

--- a/deltadewa/analysis/roll_status.py
+++ b/deltadewa/analysis/roll_status.py
@@ -260,7 +260,7 @@ def evaluate_roll_status(
         # gaining convexity on its own. If there's no time pressure and
         # crash convexity is still within target, don't force a roll that
         # was only triggered by strike drift.
-        if (
+        if (  # pylint: disable=too-many-boolean-expressions  # six independent roll-suppression guards; decomposing would obscure the policy
             verdict == RollVerdict.ROLL
             and position.option.option_type == OptionType.PUT
             and time_verdict != RollVerdict.ROLL

--- a/deltadewa/analysis/summary.py
+++ b/deltadewa/analysis/summary.py
@@ -302,8 +302,7 @@ class SummaryMixin:
         if (
             not max_loss_opts["is_unlimited"]
             and not max_profit_opts["is_unlimited"]
-            and max_profit_opts["max_profit"] > 0
-            and max_loss_opts["max_loss"] < 0
+            and max_loss_opts["max_loss"] < 0 < max_profit_opts["max_profit"]
         ):
             # Standard risk/reward ratio: profit potential to loss potential
             rr_ratio = (

--- a/deltadewa/colours.py
+++ b/deltadewa/colours.py
@@ -36,7 +36,7 @@ AFRICAN_TURQUOISE = "#000000"
 
 # Optional grouped palette
 @dataclass(frozen=True)
-class Palette:
+class Palette:  # pylint: disable=too-many-instance-attributes  # color-palette dataclass; each attribute is a named color
     """To hold colours."""
 
     positive: str = GAMMA_GREEN

--- a/deltadewa/config.py
+++ b/deltadewa/config.py
@@ -13,7 +13,7 @@ from typing import Any
 import ipywidgets as widgets  # type: ignore[import-untyped]
 
 
-class ExportDirVBox(widgets.VBox):
+class ExportDirVBox(widgets.VBox):  # pylint: disable=too-many-ancestors  # ipywidgets MRO depth; not our code
     """Custom VBox to hold export directory configuration and metadata."""
 
     def __init__(self, *args: Any, export_dir: Path, **kwargs: Any) -> None:  # noqa: ANN401

--- a/deltadewa/formatters/dataframes.py
+++ b/deltadewa/formatters/dataframes.py
@@ -463,7 +463,7 @@ def format_pivot_table(
     pivot: pd.DataFrame,
     format_str: str = "{:,.2f}",
     cmap: str = "RdYlGn",
-    highlight_zeros: bool = True,  # noqa: ARG001
+    _highlight_zeros: bool = True,
 ) -> Styler:
     """Format pivot table with consistent styling.
 
@@ -471,7 +471,7 @@ def format_pivot_table(
         pivot: Pivot table DataFrame
         format_str: Format string for cell values
         cmap: Colormap for background gradient
-        highlight_zeros: Whether to highlight zero/near-zero values
+        _highlight_zeros: Reserved; zero-highlighting not yet implemented.
 
     Returns:
         Styled pivot table

--- a/deltadewa/formatters/gradients.py
+++ b/deltadewa/formatters/gradients.py
@@ -30,7 +30,7 @@ def create_heatmap_style(
     df: pd.DataFrame,
     cmap: str = "RdYlGn",
     format_str: str = "{:,.2f}",
-    center_value: float | None = None,  # noqa: ARG001
+    _center_value: float | None = None,
     vmin: float | None = None,
     vmax: float | None = None,
 ) -> Styler:
@@ -42,7 +42,8 @@ def create_heatmap_style(
         df: Input DataFrame
         cmap: Colormap name
         format_str: Format string for values
-        center_value: Value to center colormap at (e.g., 0 for diverging colors)
+        _center_value: Reserved; not currently applied (use vmin/vmax or
+            apply_financial_gradient_2d for diverging scales).
         vmin: Minimum value for color scale
         vmax: Maximum value for color scale
 

--- a/deltadewa/persistence.py
+++ b/deltadewa/persistence.py
@@ -13,8 +13,8 @@ from typing import Any
 
 import pandas as pd
 
-from deltadewa import OptionPortfolio
 from deltadewa.constants import ExerciseStyle, OptionType
+from deltadewa.portfolio.core import OptionPortfolio
 from deltadewa.reporting import PortfolioLogger
 
 try:

--- a/deltadewa/valuation.py
+++ b/deltadewa/valuation.py
@@ -12,7 +12,7 @@ from deltadewa.greeks_cache import GreeksCache
 from deltadewa.warnings import ClosedFormAccuracyWarning
 
 
-class OptionValuation:
+class OptionValuation:  # pylint: disable=too-many-instance-attributes  # QuantLib wrapper needs all market/model params as attributes
     """Option pricing engine.
 
     Supports both American (Finite Difference) and European (Analytic

--- a/deltadewa/visualization/convenience.py
+++ b/deltadewa/visualization/convenience.py
@@ -22,6 +22,19 @@ if TYPE_CHECKING:
     from deltadewa.portfolio.core import OptionPortfolio, OptionPortfolioBase
 
 
+def _annotate_no_data(ax: Axes) -> None:
+    """Show a centred 'No data' label and turn the axis off."""
+    ax.text(
+        0.5,
+        0.5,
+        "No data",
+        ha="center",
+        va="center",
+        transform=ax.transAxes,
+    )
+    ax.axis("off")
+
+
 @overload
 def plot_pnl_diagram(
     portfolio: OptionPortfolio,
@@ -242,15 +255,7 @@ def plot_greeks_consolidated(
                         fontsize=8,
                     )
         else:
-            ax.text(
-                0.5,
-                0.5,
-                "No data",
-                ha="center",
-                va="center",
-                transform=ax.transAxes,
-            )
-            ax.axis("off")
+            _annotate_no_data(ax)
 
     # Detailed panels (if requested)
     # Panel 3: Top Vega Contributors
@@ -277,15 +282,7 @@ def plot_greeks_consolidated(
         _set_axis_formatting(ax, f"Top {top_n} Vega Contributors", yint=yint)
 
     else:
-        ax.text(
-            0.5,
-            0.5,
-            "No data",
-            ha="center",
-            va="center",
-            transform=ax.transAxes,
-        )
-        ax.axis("off")
+        _annotate_no_data(ax)
 
     # Panel 4: Top Theta Contributors
     ax = axes[1, 1]
@@ -340,15 +337,7 @@ def plot_greeks_consolidated(
         )
         ax.xaxis.set_major_formatter(FuncFormatter(format_currency_for_axis))
     else:
-        ax.text(
-            0.5,
-            0.5,
-            "No data",
-            ha="center",
-            va="center",
-            transform=ax.transAxes,
-        )
-        ax.axis("off")
+        _annotate_no_data(ax)
 
     # Panel 6: Value by Maturity
     ax = axes[2, 1]
@@ -384,15 +373,7 @@ def plot_greeks_consolidated(
         )
         ax.xaxis.set_major_formatter(FuncFormatter(format_currency_for_axis))
     else:
-        ax.text(
-            0.5,
-            0.5,
-            "No data",
-            ha="center",
-            va="center",
-            transform=ax.transAxes,
-        )
-        ax.axis("off")
+        _annotate_no_data(ax)
 
     # Panel 7: Greeks by Strike
     ax = axes[3, 0]
@@ -411,15 +392,7 @@ def plot_greeks_consolidated(
         _set_axis_formatting(ax, "Greeks by Strike", xint=xint)
 
     else:
-        ax.text(
-            0.5,
-            0.5,
-            "No data",
-            ha="center",
-            va="center",
-            transform=ax.transAxes,
-        )
-        ax.axis("off")
+        _annotate_no_data(ax)
 
     # Panel 8: Greeks by Maturity
     ax = axes[3, 1]
@@ -440,14 +413,6 @@ def plot_greeks_consolidated(
         xint, _ = ax.get_xlim()
         _set_axis_formatting(ax, "Greeks by Maturity", xint=xint)
     else:
-        ax.text(
-            0.5,
-            0.5,
-            "No data",
-            ha="center",
-            va="center",
-            transform=ax.transAxes,
-        )
-        ax.axis("off")
+        _annotate_no_data(ax)
 
     return fig

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -99,3 +99,45 @@ filterwarnings = [
 	"ignore:builtin type SwigPyObject has no __module__ attribute:DeprecationWarning",
 	"ignore:builtin type swigvarlink has no __module__ attribute:DeprecationWarning",
 ]
+
+[tool.pylint.main]
+py-version = "3.11"
+jobs = 0
+ignore-paths = ["typings"]
+fail-under = 10.0
+
+[tool.pylint.format]
+max-line-length = 80
+
+[tool.pylint."messages control"]
+disable = [
+  "line-too-long", "trailing-whitespace", "missing-final-newline",
+  "unused-import", "wrong-import-order", "wrong-import-position", "ungrouped-imports",
+  "invalid-name",
+  "missing-module-docstring", "missing-class-docstring", "missing-function-docstring",
+  "import-error",
+  "too-few-public-methods",
+  # R0917 always co-fires with R0913; keeping one source of truth for arity
+  "too-many-positional-arguments",
+  # C0302 large but cohesive widget/dashboard modules are acceptable
+  "too-many-lines",
+]
+
+[tool.pylint.design]
+# Limits set to the observed codebase ceiling — any future code exceeding these
+# is a genuine regression.  Comments name the current ceiling holder.
+max-args        = 18   # widgets/gauges.py GaugeIndicator.__init__
+max-locals      = 65   # visualization/pnl_charts.py plot_pnl_distribution_with_metrics
+max-attributes  = 27   # deltadewa/valuation.py OptionValuation (QuantLib wrapper)
+max-branches    = 22   # analysis/summary.py format_risk_reward_summary
+max-statements  = 130  # visualization/convenience.py plot_greeks_consolidated
+max-returns     = 8    # analysis/decision_matrix.py
+max-bool-expr   = 6    # analysis/roll_status.py _check_roll_verdict
+
+[tool.pylint.similarities]
+# Short patterns (6-10 lines) are typically calling-convention idioms for the
+# same shared API, not structural duplication worth extracting.  Genuine
+# R0801 findings still surface at 12+ lines.
+min-similarity-lines = 12
+ignore-imports       = true   # import blocks appear in every module; skip them
+ignore-docstrings    = true   # docstring templates are not logic duplication


### PR DESCRIPTION
## Summary

Adds pylint ≥4.0.4 as a complementary static-analysis gate alongside ruff and mypy. pylint's unique scope is **duplicate-code (R0801), cyclic-imports (R0401), and design-complexity limits** — checks that ruff and mypy don't perform.

### Baseline → post-triage
| | Score |
|---|---|
| Baseline (no config) | 9.69/10 — ~186 findings |
| Post-config + triage | **10.00/10** — 0 findings |
| `fail-under` threshold | **10.0** |

---

## Config decisions (`pyproject.toml`)

- **Disabled (owned by ruff):** format, imports, naming, docstrings, unused-import, invalid-name
- **Disabled (owned by mypy):** import-error
- **Disabled globally (R0917):** `too-many-positional-arguments` always co-fires with R0913 in pylint 4.x — keeping one source of truth
- **Design limits** raised to observed codebase ceilings, each comment naming the ceiling holder; any future code exceeding them is a genuine regression
- **`min-similarity-lines = 12`** for R0801 — the 186 baseline findings included 12 R0801 hits, all 6–11 lines of calling-convention idioms (common matplotlib/ipywidgets API patterns). Genuine structural duplication of 12+ lines still surfaces.
- **`fail-under = 10.0`** gates on the actual post-triage score; pylint exits non-zero if score drops

---

## Code changes

| File | Change | Reason |
|---|---|---|
| `deltadewa/persistence.py` | `from deltadewa import OptionPortfolio` → `from deltadewa.portfolio.core import OptionPortfolio` | **Fixed cyclic import (R0401)** — package root imports widgets which imports persistence; bypassing root breaks the cycle |
| `deltadewa/visualization/convenience.py` | Extract `_annotate_no_data` helper | **Fixed R0801** — six identical inline "No data" blocks consolidated |
| `deltadewa/analysis/summary.py` | Rewrite `a > 0 and b < 0` → `b < 0 < a` | **Fixed R1716** chained comparison |
| `deltadewa/formatters/gradients.py` | `center_value` → `_center_value`, docstring updated | **Fixed W0613** unused argument (no more `noqa: ARG001`) |
| `deltadewa/formatters/dataframes.py` | `highlight_zeros` → `_highlight_zeros`, docstring updated | **Fixed W0613** unused argument (no more `noqa: ARG001`) |
| `deltadewa/colours.py` | `# pylint: disable=too-many-instance-attributes` on `Palette` | Justified: color-palette dataclass, each attribute is a named color |
| `deltadewa/valuation.py` | `# pylint: disable=too-many-instance-attributes` on `OptionValuation` | Justified: QuantLib wrapper needs all market/model params as attributes |
| `deltadewa/analysis/base.py` | `# pylint: disable=too-many-ancestors` on `PortfolioAnalyzer` | Justified: mixin architecture; each mixin is a separate concern |
| `deltadewa/config.py` | `# pylint: disable=too-many-ancestors` on `ExportDirVBox` | Justified: ipywidgets MRO depth; not our code |
| `deltadewa/analysis/roll_status.py` | `# pylint: disable=too-many-boolean-expressions` on the suppression guard | Justified: six independent roll-suppression guards; decomposing would obscure the policy |

**Design limits** (too-many-args/locals/branches/statements/returns/bool-expr): handled by raising config limits to the codebase ceiling — no per-line disables scattered through the code.

---

## CLAUDE.md

Added `poetry run pylint deltadewa` to the gate command list with a scope note; updated the "before considering any change done" sentence to include pylint.

---

## Not in scope

CI wiring (GitHub Actions) is tracked as **issue #1** and will reuse this exact command (`poetry run pylint deltadewa`). This PR establishes the config and green baseline; CI is the follow-on.

---

## Gate

```
pytest         974/974 passed ✅
mypy           0 issues in 174 source files ✅
ruff check     clean ✅
pylint         10.00/10  exit 0 ✅
nbqa ruff      monitor_dashboard.ipynb ✅  hedge_design.ipynb ✅
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)