### PR TITLE
feat: stable position identity via position_id field (closes #71)

### DIFF
--- a/deltadewa/persistence.py
+++ b/deltadewa/persistence.py
@@ -151,6 +151,7 @@ class PortfolioSerializer:
 
         for pos in portfolio.positions:
             position_data = {
+                "position_id": pos.position_id,
                 "option_type": pos.option.option_type.value,
                 "strike_price": pos.option.strike_price,
                 "maturity_date": pos.option.maturity_date.isoformat(),
@@ -428,6 +429,8 @@ class PortfolioSerializer:
                 dt.fromisoformat(raw_entry_date) if raw_entry_date else None
             )
             new_position.entry_premium = pos_data.get("entry_premium")
+            if pid := pos_data.get("position_id"):
+                new_position.position_id = pid
 
         return {
             "portfolio": imported_portfolio,
@@ -521,6 +524,8 @@ class PortfolioSerializer:
                 dt.fromisoformat(raw_entry_date) if raw_entry_date else None
             )
             new_position.entry_premium = pos_config.get("entry_premium")
+            if pid := pos_config.get("position_id"):
+                new_position.position_id = pid
 
         return {
             "portfolio": imported_portfolio,

--- a/deltadewa/portfolio/core.py
+++ b/deltadewa/portfolio/core.py
@@ -84,7 +84,7 @@ class OptionPortfolioBase:
         exercise_style: ExerciseStyle | None = None,
         entry_spot: float | None = None,
         entry_date: dt | None = None,
-    ) -> None:
+    ) -> OptionPosition:
         """Add an option position to the portfolio.
 
         Args:
@@ -102,6 +102,9 @@ class OptionPortfolioBase:
                 (uses self.default_exercise_style if None)
             entry_spot: Spot price at entry (uses self.spot_price if None)
             entry_date: Date of entry (uses self.valuation_date if None)
+
+        Returns:
+            The newly created and appended OptionPosition.
 
         """
         effective_cs = (
@@ -146,6 +149,7 @@ class OptionPortfolioBase:
             entry_date=entry_date,
         )
         self.positions.append(position)
+        return position
 
     def set_volatility(self, volatility: float) -> None:
         """Set portfolio volatility.

--- a/deltadewa/portfolio/position.py
+++ b/deltadewa/portfolio/position.py
@@ -1,5 +1,6 @@
 """Option position representation."""
 
+import uuid
 from datetime import datetime as dt
 from typing import Any
 
@@ -20,6 +21,7 @@ class OptionPosition:
         entry_spot: float | None = None,
         entry_date: dt | None = None,
         entry_premium: float | None = None,
+        position_id: str = "",
     ) -> None:
         """Initialize an option position.
 
@@ -37,6 +39,10 @@ class OptionPosition:
             entry_premium: Per-share option price paid at entry, or None if
             unknown.  Total cost-basis = entry_premium * abs(quantity) *
             contract_size.
+            position_id: Stable runtime identity for this position.  When
+            empty (the default) a fresh UUID is generated automatically.
+            Pass an explicit value only when restoring a serialized position
+            so that save→load preserves identity.
 
         """
         self.option = option
@@ -47,6 +53,7 @@ class OptionPosition:
         self.entry_spot = entry_spot
         self.entry_date = entry_date
         self.entry_premium = entry_premium
+        self.position_id = position_id if position_id else str(uuid.uuid4())
 
     def position_value(self) -> float:
         """Calculate the total value of the position.
@@ -85,6 +92,7 @@ class OptionPosition:
         multiplier = self.quantity * self.contract_size
 
         return {
+            "position_id": self.position_id,
             "option_type": self.option.option_type,
             "strike": self.option.strike_price,
             "maturity": self.option.maturity_date,

--- a/deltadewa/reporting/audit.py
+++ b/deltadewa/reporting/audit.py
@@ -29,6 +29,7 @@ from deltadewa.constants import PortfolioAction
 
 if TYPE_CHECKING:
     from deltadewa.portfolio.core import OptionPortfolio
+    from deltadewa.portfolio.position import OptionPosition
     from deltadewa.reporting.console import ConsoleReporter
 
 
@@ -251,12 +252,14 @@ class PortfolioChangeTracker:
     def track(self) -> None:
         """Diff current portfolio state against the last snapshot and log.
 
-        Infers the action type from the change in position count:
+        Uses position_id set-difference to infer the action type:
 
-        - count increased  → ``ADD``
-        - count decreased  → ``REMOVE``
-        - count unchanged  → ``UPDATE``
+        - IDs appeared   → ``ADD``   (one log entry per new position)
+        - IDs disappeared → ``REMOVE`` (one log entry per removed position)
+        - IDs unchanged  → ``UPDATE``
 
+        Removed positions are described from the prior snapshot's id→desc map
+        so their details survive after they are gone from the live portfolio.
         Also marks Monte Carlo results stale when they exist.
         """
         pf = self._portfolio
@@ -268,29 +271,48 @@ class PortfolioChangeTracker:
             return
 
         last = self._last_state
-
-        # --- infer action and build detail string ---
-        if current["positions"] > last["positions"]:
-            action = PortfolioAction.ADD
-            details = self._describe_last_added(pf)
-        elif current["positions"] < last["positions"]:
-            action = PortfolioAction.REMOVE
-            details = f"Removed position (total now: {current['positions']})"
-        else:
-            action = PortfolioAction.UPDATE
-            details = "Updated position"
-
         delta_change = current["delta"] - last["delta"]
         value_change = current["value"] - last["value"]
 
-        self._logger.log_portfolio_change(
-            portfolio=pf,
-            action_type=action,
-            details=details,
-            impact_delta=delta_change,
-            impact_cost=value_change,
-            position_id=None,
-        )
+        added_ids = current["position_ids"] - last["position_ids"]
+        removed_ids = last["position_ids"] - current["position_ids"]
+
+        if added_ids:
+            id_to_pos = {p.position_id: p for p in pf.positions}
+            for pos_id in added_ids:
+                self._logger.log_portfolio_change(
+                    portfolio=pf,
+                    action_type=PortfolioAction.ADD,
+                    details=(
+                        f"Added {self._describe_position(id_to_pos[pos_id])}"
+                    ),
+                    impact_delta=delta_change,
+                    impact_cost=value_change,
+                    position_id=pos_id,
+                )
+        elif removed_ids:
+            for pos_id in removed_ids:
+                desc = last["id_to_desc"].get(pos_id, "position")
+                self._logger.log_portfolio_change(
+                    portfolio=pf,
+                    action_type=PortfolioAction.REMOVE,
+                    details=(
+                        f"Removed {desc}"
+                        f" (total now: {current['positions']})"
+                    ),
+                    impact_delta=delta_change,
+                    impact_cost=value_change,
+                    position_id=pos_id,
+                )
+        else:
+            self._logger.log_portfolio_change(
+                portfolio=pf,
+                action_type=PortfolioAction.UPDATE,
+                details="Updated position",
+                impact_delta=delta_change,
+                impact_cost=value_change,
+                position_id=None,
+            )
 
         # Mark Monte Carlo results stale if they exist
         if getattr(pf, "monte_carlo_results", None):
@@ -301,8 +323,11 @@ class PortfolioChangeTracker:
         self._last_state = current
 
         if self._reporter is not None:
-            ts = self._logger.get_last_entry()["timestamp"].strftime("%H:%M:%S")
-            self._reporter.success(f"Change logged: {action} at {ts}")
+            last_entry = self._logger.get_last_entry()
+            ts = last_entry["timestamp"].strftime("%H:%M:%S")
+            self._reporter.success(
+                f"Change logged: {last_entry['action']} at {ts}",
+            )
 
     def as_callback(self) -> Callable[[], None]:
         """Return a zero-argument callable that calls :meth:`track`.
@@ -332,22 +357,18 @@ class PortfolioChangeTracker:
             "positions": len(portfolio.positions),
             "delta": portfolio.total_delta(),
             "value": portfolio.total_value(),
+            "position_ids": {p.position_id for p in portfolio.positions},
+            "id_to_desc": {
+                p.position_id: PortfolioChangeTracker._describe_position(p)
+                for p in portfolio.positions
+            },
         }
 
     @staticmethod
-    def _describe_last_added(portfolio: OptionPortfolio) -> str:
-        """Build a human-readable description of last added position."""
-        # This is a bit hacky since it relies on the assumption that the
-        # last position in the list is the one just added, but it works for our
-        # current use case and keeps the logger decoupled from the portfolio
-        # internals.
-        # https://github.com/qwertytam/deltadewa/issues/71
-
-        if not portfolio.positions:
-            return "Added position"
-        pos = portfolio.positions[-1]
+    def _describe_position(pos: OptionPosition) -> str:
+        """Return a short human-readable label for *pos*."""
         return (
-            f"Added {pos.quantity}x "
+            f"{pos.quantity}x "
             f"{pos.option.option_type.upper()} "
             f"${pos.option.strike_price:.0f} "
             f"exp {pos.option.maturity_date.strftime('%Y-%m-%d')}"

--- a/examples/.env.example
+++ b/examples/.env.example
@@ -1,2 +1,2 @@
 # .env.example
-USE_LIVE=False
+_USE_LIVE=False

--- a/hedge_design.ipynb
+++ b/hedge_design.ipynb
@@ -64,7 +64,7 @@
     "# Set True for live CBOE/FRED data (requires internet:\n",
     "# cdn.cboe.com, fred.stlouisfed.org). Automatically falls back to\n",
     "# static if the network is unavailable. Default False = offline-safe.\n",
-    "# See /examples/.env.example for how to set USE_LIVE=True in your environment.\n",
+    "# See /examples/.env.example for how to set _USE_LIVE=True in your environment.\n",
     "_USE_LIVE = os.environ.get(\"_USE_LIVE\", \"False\") == \"True\"\n",
     "\n",
     "# Dashboard session: portfolio, market data provider, IPS policy,\n",

--- a/monitor_dashboard.ipynb
+++ b/monitor_dashboard.ipynb
@@ -76,7 +76,7 @@
     "# Set True for live CBOE/FRED data (requires internet:\n",
     "# cdn.cboe.com, fred.stlouisfed.org). Automatically falls back to\n",
     "# static if the network is unavailable. Default False = offline-safe.\n",
-    "# See /examples/.env.example for how to set USE_LIVE=True in your environment.\n",
+    "# See /examples/.env.example for how to set _USE_LIVE=True in your environment.\n",
     "_USE_LIVE = os.environ.get(\"_USE_LIVE\", \"False\") == \"True\"\n",
     "\n",
     "# Dashboard session: portfolio, market data provider, IPS policy,\n",

--- a/tests/test_persistence.py
+++ b/tests/test_persistence.py
@@ -442,6 +442,28 @@ class TestJsonRoundtrip:
         with pytest.raises(ValueError, match="missing strike price"):
             serializer.import_from_json(json_path, create_portfolio=True)
 
+    def test_json_roundtrip_preserves_position_id(
+        self,
+        tmp_path,
+        sample_portfolio,
+    ) -> None:
+        """Export then import JSON — position_id must survive the round-trip."""
+        serializer = PortfolioSerializer(tmp_path)
+        changelog = PortfolioLogger()
+
+        original_ids = [p.position_id for p in sample_portfolio.positions]
+
+        output_path = serializer.export_to_json(
+            sample_portfolio,
+            changelog,
+            "test.json",
+        )
+        result = serializer.import_from_json(output_path, create_portfolio=True)
+        imported_portfolio = result["portfolio"]
+
+        imported_ids = [p.position_id for p in imported_portfolio.positions]
+        assert imported_ids == original_ids
+
 
 # ========== YAML Roundtrip Tests ==========
 
@@ -584,6 +606,41 @@ class TestYamlRoundtrip:
             position.option.maturity_date - datetime.now(tz=UTC)
         ).total_seconds() / 86400
         assert time_to_maturity == pytest.approx(30, abs=1)
+
+    def test_yaml_import_without_position_id_gets_fresh_uuid(
+        self,
+        tmp_path,
+    ) -> None:
+        """Hand-authored YAML without position_id → auto-generated UUID."""
+        config = {
+            "market_parameters": {
+                "spot_price": 100.0,
+                "volatility": 0.3,
+                "risk_free_rate": 0.05,
+                "dividend_yield": 0.02,
+                "underlying_quantity": 0.0,
+                "symbol": "TEST",
+                "contract_size": 100,
+            },
+            "positions": [
+                {
+                    "option_type": OptionType.CALL.value,
+                    "strike_price": 100.0,
+                    "maturity_days": 30,
+                    "quantity": 1,
+                    # deliberately no position_id key
+                },
+            ],
+        }
+        yaml_path = tmp_path / "no_id.yaml"
+        with Path.open(yaml_path, "w", encoding="utf-8") as f:
+            yaml.dump(config, f)
+
+        serializer = PortfolioSerializer(tmp_path)
+        result = serializer.import_from_yaml(yaml_path)
+        pos = result["portfolio"].positions[0]
+        assert isinstance(pos.position_id, str)
+        assert pos.position_id != ""
 
 
 # ========== CSV Export Tests ==========

--- a/tests/test_portfolio/test_core.py
+++ b/tests/test_portfolio/test_core.py
@@ -126,6 +126,19 @@ class TestOptionPortfolioBase:
         except IndexError:
             pass
 
+    def test_add_position_returns_appended_position(self) -> None:
+        """add_position returns the object that was appended to positions."""
+        portfolio = OptionPortfolioBase(spot_price=100.0, volatility=0.2)
+        returned = portfolio.add_position(
+            strike_price=100.0,
+            maturity_date=datetime.now(tz=UTC) + timedelta(days=30),
+            quantity=1,
+            option_type=OptionType.CALL,
+        )
+        assert returned is portfolio.positions[-1]
+        assert isinstance(returned.position_id, str)
+        assert returned.position_id != ""
+
     def test_update_position(self) -> None:
         """Test updating a position."""
         portfolio = OptionPortfolioBase(symbol="TEST")
@@ -194,6 +207,26 @@ class TestOptionPortfolioBase:
             "OptionValuation.exercise_style reverted after "
             "update_market_conditions"
         )
+
+    def test_update_position_preserves_position_id(self) -> None:
+        """update_position keeps same object; position_id is stable."""
+        portfolio = OptionPortfolioBase(spot_price=100.0, volatility=0.2)
+        portfolio.add_position(
+            strike_price=100.0,
+            maturity_date=datetime.now(tz=UTC) + timedelta(days=30),
+            quantity=1,
+            option_type=OptionType.CALL,
+        )
+        original_id = portfolio.positions[0].position_id
+        assert original_id != ""
+
+        # Update quantity (field mutation — no OptionValuation rebuild)
+        portfolio.update_position(0, quantity=5)
+        assert portfolio.positions[0].position_id == original_id
+
+        # Update strike (triggers OptionValuation rebuild inside OptionPosition)
+        portfolio.update_position(0, strike=110.0)
+        assert portfolio.positions[0].position_id == original_id
 
     def test_clear_positions(self) -> None:
         """Test clearing all positions."""

--- a/tests/test_portfolio/test_position.py
+++ b/tests/test_portfolio/test_position.py
@@ -203,6 +203,77 @@ class TestOptionPosition:
         assert "entry_premium" in d
         assert d["entry_premium"] is None
 
+    def test_position_id_auto_generated(self) -> None:
+        """position_id is a non-empty string when not supplied."""
+        option = OptionValuation(
+            spot_price=100.0,
+            strike_price=100.0,
+            maturity_date=datetime.now(tz=UTC) + timedelta(days=30),
+            volatility=0.2,
+            risk_free_rate=0.05,
+            dividend_yield=0.0,
+            option_type=OptionType.CALL,
+        )
+        position = OptionPosition(option=option, quantity=1)
+        assert isinstance(position.position_id, str)
+        assert position.position_id != ""
+
+    def test_position_id_unique_per_instance(self) -> None:
+        """Two independently created positions get different IDs."""
+        maturity = datetime.now(tz=UTC) + timedelta(days=30)
+        option_a = OptionValuation(
+            spot_price=100.0,
+            strike_price=100.0,
+            maturity_date=maturity,
+            volatility=0.2,
+            risk_free_rate=0.05,
+            dividend_yield=0.0,
+            option_type=OptionType.CALL,
+        )
+        option_b = OptionValuation(
+            spot_price=100.0,
+            strike_price=105.0,
+            maturity_date=maturity,
+            volatility=0.2,
+            risk_free_rate=0.05,
+            dividend_yield=0.0,
+            option_type=OptionType.PUT,
+        )
+        pos_a = OptionPosition(option=option_a, quantity=1)
+        pos_b = OptionPosition(option=option_b, quantity=1)
+        assert pos_a.position_id != pos_b.position_id
+
+    def test_position_id_explicit_restored(self) -> None:
+        """An explicit position_id is stored verbatim (serializer restore)."""
+        option = OptionValuation(
+            spot_price=100.0,
+            strike_price=100.0,
+            maturity_date=datetime.now(tz=UTC) + timedelta(days=30),
+            volatility=0.2,
+            risk_free_rate=0.05,
+            dividend_yield=0.0,
+            option_type=OptionType.CALL,
+        )
+        pid = "fixed-id-for-test"
+        position = OptionPosition(option=option, quantity=1, position_id=pid)
+        assert position.position_id == pid
+
+    def test_to_dict_includes_position_id(self) -> None:
+        """to_dict() includes position_id key."""
+        option = OptionValuation(
+            spot_price=100.0,
+            strike_price=100.0,
+            maturity_date=datetime.now(tz=UTC) + timedelta(days=30),
+            volatility=0.2,
+            risk_free_rate=0.05,
+            dividend_yield=0.0,
+            option_type=OptionType.CALL,
+        )
+        position = OptionPosition(option=option, quantity=1)
+        d = position.to_dict()
+        assert "position_id" in d
+        assert d["position_id"] == position.position_id
+
     def test_custom_volatility_flag(self) -> None:
         """Test custom_volatility flag."""
         option = OptionValuation(

--- a/tests/test_reporting/test_audit.py
+++ b/tests/test_reporting/test_audit.py
@@ -1,0 +1,265 @@
+"""Tests for deltadewa.reporting.audit — PortfolioChangeTracker."""
+
+from datetime import UTC, datetime, timedelta
+
+from deltadewa.constants import OptionType, PortfolioAction
+from deltadewa.portfolio.core import OptionPortfolio
+from deltadewa.reporting.audit import PortfolioChangeTracker, PortfolioLogger
+
+# ---------------------------------------------------------------------------
+# Shared helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_portfolio() -> OptionPortfolio:
+    return OptionPortfolio(
+        spot_price=100.0,
+        volatility=0.2,
+        risk_free_rate=0.05,
+        dividend_yield=0.0,
+    )
+
+
+def _maturity(days: int = 30) -> datetime:
+    return datetime.now(tz=UTC) + timedelta(days=days)
+
+
+# ---------------------------------------------------------------------------
+# _snapshot
+# ---------------------------------------------------------------------------
+
+
+class TestSnapshot:
+    """Unit tests for PortfolioChangeTracker._snapshot."""
+
+    def test_snapshot_has_position_ids_and_id_to_desc(self) -> None:
+        """_snapshot includes position_ids (set) and id_to_desc (dict)."""
+        pf = _make_portfolio()
+        pos = pf.add_position(
+            strike_price=100.0,
+            maturity_date=_maturity(),
+            quantity=1,
+            option_type=OptionType.CALL,
+        )
+        snap = PortfolioChangeTracker._snapshot(pf)
+
+        assert "position_ids" in snap
+        assert "id_to_desc" in snap
+        assert pos.position_id in snap["position_ids"]
+        assert pos.position_id in snap["id_to_desc"]
+
+    def test_snapshot_empty_portfolio(self) -> None:
+        """_snapshot on an empty portfolio has empty sets/dicts."""
+        pf = _make_portfolio()
+        snap = PortfolioChangeTracker._snapshot(pf)
+
+        assert snap["position_ids"] == set()
+        assert snap["id_to_desc"] == {}
+        assert snap["positions"] == 0
+
+
+# ---------------------------------------------------------------------------
+# track() — ADD
+# ---------------------------------------------------------------------------
+
+
+class TestTrackAdd:
+    """track() correctly logs ADD events with real position_ids."""
+
+    def test_single_add_logs_correct_position_id(self) -> None:
+        """Adding one position → one ADD entry with the position's id."""
+        pf = _make_portfolio()
+        logger = PortfolioLogger()
+        tracker = PortfolioChangeTracker(pf, logger)
+
+        pos = pf.add_position(
+            strike_price=100.0,
+            maturity_date=_maturity(),
+            quantity=2,
+            option_type=OptionType.PUT,
+        )
+        tracker.track()
+
+        entry = logger.get_last_entry()
+        assert entry["action"] == PortfolioAction.ADD
+        assert entry["position_id"] == pos.position_id
+        assert entry["position_id"] is not None
+
+    def test_single_add_details_describe_position(self) -> None:
+        """ADD entry details mention the strike and quantity."""
+        pf = _make_portfolio()
+        logger = PortfolioLogger()
+        tracker = PortfolioChangeTracker(pf, logger)
+
+        pf.add_position(
+            strike_price=105.0,
+            maturity_date=_maturity(),
+            quantity=3,
+            option_type=OptionType.CALL,
+        )
+        tracker.track()
+
+        details = logger.get_last_entry()["details"]
+        assert "105" in details
+        assert "3x" in details
+
+    def test_bulk_add_logs_one_entry_per_position(self) -> None:
+        """Adding two positions before a single track() → two ADD entries."""
+        pf = _make_portfolio()
+        logger = PortfolioLogger()
+        tracker = PortfolioChangeTracker(pf, logger)
+
+        pos_a = pf.add_position(
+            strike_price=100.0,
+            maturity_date=_maturity(30),
+            quantity=1,
+            option_type=OptionType.CALL,
+        )
+        pos_b = pf.add_position(
+            strike_price=110.0,
+            maturity_date=_maturity(60),
+            quantity=2,
+            option_type=OptionType.PUT,
+        )
+        tracker.track()  # called once after both adds
+
+        add_entries = [
+            e for e in logger.get_all_entries()
+            if e["action"] == PortfolioAction.ADD
+        ]
+        assert len(add_entries) == 2
+
+        logged_ids = {e["position_id"] for e in add_entries}
+        assert pos_a.position_id in logged_ids
+        assert pos_b.position_id in logged_ids
+
+    def test_bulk_add_position_ids_are_not_none(self) -> None:
+        """Every ADD entry from a bulk track() has a non-None position_id."""
+        pf = _make_portfolio()
+        logger = PortfolioLogger()
+        tracker = PortfolioChangeTracker(pf, logger)
+
+        pf.add_position(100.0, _maturity(30), 1, OptionType.CALL)
+        pf.add_position(105.0, _maturity(60), 1, OptionType.PUT)
+        tracker.track()
+
+        for entry in logger.get_all_entries():
+            if entry["action"] == PortfolioAction.ADD:
+                assert entry["position_id"] is not None
+
+
+# ---------------------------------------------------------------------------
+# track() — REMOVE
+# ---------------------------------------------------------------------------
+
+
+class TestTrackRemove:
+    """track() correctly logs REMOVE events with real position_ids."""
+
+    def test_remove_logs_correct_position_id(self) -> None:
+        """Removing a position → REMOVE entry carries the original id."""
+        pf = _make_portfolio()
+        logger = PortfolioLogger()
+        tracker = PortfolioChangeTracker(pf, logger)
+
+        pos = pf.add_position(
+            strike_price=100.0,
+            maturity_date=_maturity(),
+            quantity=1,
+            option_type=OptionType.CALL,
+        )
+        tracker.track()  # baseline: one position present
+
+        original_id = pos.position_id
+        pf.remove_position(0)
+        tracker.track()  # should log REMOVE
+
+        remove_entries = [
+            e for e in logger.get_all_entries()
+            if e["action"] == PortfolioAction.REMOVE
+        ]
+        assert len(remove_entries) == 1
+        assert remove_entries[0]["position_id"] == original_id
+
+    def test_remove_entry_position_id_not_none(self) -> None:
+        """REMOVE entry has a non-None position_id."""
+        pf = _make_portfolio()
+        logger = PortfolioLogger()
+        tracker = PortfolioChangeTracker(pf, logger)
+
+        pf.add_position(100.0, _maturity(), 1, OptionType.PUT)
+        tracker.track()
+        pf.remove_position(0)
+        tracker.track()
+
+        remove_entry = next(
+            e for e in logger.get_all_entries()
+            if e["action"] == PortfolioAction.REMOVE
+        )
+        assert remove_entry["position_id"] is not None
+
+    def test_remove_details_describe_original_position(self) -> None:
+        """REMOVE entry details survive after the position is gone."""
+        pf = _make_portfolio()
+        logger = PortfolioLogger()
+        tracker = PortfolioChangeTracker(pf, logger)
+
+        pf.add_position(
+            strike_price=95.0,
+            maturity_date=_maturity(),
+            quantity=4,
+            option_type=OptionType.PUT,
+        )
+        tracker.track()
+        pf.remove_position(0)
+        tracker.track()
+
+        remove_entry = next(
+            e for e in logger.get_all_entries()
+            if e["action"] == PortfolioAction.REMOVE
+        )
+        assert "95" in remove_entry["details"]
+        assert "4x" in remove_entry["details"]
+
+
+# ---------------------------------------------------------------------------
+# track() — UPDATE
+# ---------------------------------------------------------------------------
+
+
+class TestTrackUpdate:
+    """track() correctly logs UPDATE events."""
+
+    def test_update_logs_update_action(self) -> None:
+        """Updating a position (count unchanged) → UPDATE entry."""
+        pf = _make_portfolio()
+        logger = PortfolioLogger()
+        tracker = PortfolioChangeTracker(pf, logger)
+
+        pf.add_position(100.0, _maturity(), 1, OptionType.CALL)
+        tracker.track()
+
+        pf.update_position(0, quantity=5)
+        tracker.track()
+
+        update_entries = [
+            e for e in logger.get_all_entries()
+            if e["action"] == PortfolioAction.UPDATE
+        ]
+        assert len(update_entries) == 1
+
+    def test_no_spurious_add_remove_on_update(self) -> None:
+        """Updating a position must not produce extra ADD or any REMOVE."""
+        pf = _make_portfolio()
+        logger = PortfolioLogger()
+        tracker = PortfolioChangeTracker(pf, logger)
+
+        pf.add_position(100.0, _maturity(), 1, OptionType.CALL)
+        tracker.track()  # one ADD
+
+        pf.update_position(0, quantity=5)
+        tracker.track()  # must log UPDATE, not a second ADD or any REMOVE
+
+        counts = logger.get_action_counts()
+        assert counts.get(PortfolioAction.ADD, 0) == 1
+        assert counts.get(PortfolioAction.REMOVE, 0) == 0


### PR DESCRIPTION
## Summary

- **`OptionPosition.position_id`** (UUID4): auto-generated at construction; explicit value accepted so the serializer can restore a saved ID. Stable across `update_position` (same object mutated in-place).
- **`add_position` return type**: changed from `-> None` to `-> OptionPosition`, returning the appended position. Backward-safe for callers that ignore the return value.
- **Audit tracker rework** (`audit.py`): `_snapshot()` now captures `position_ids` (set) and `id_to_desc` (id → description built before removal). `track()` uses set-difference (`added_ids / removed_ids`) instead of count comparison, logging one entry per changed position with the real `position_id` populated. Bulk-add (multiple `add_position` calls before a single `track()`) correctly emits one `ADD` entry per position. Removed positions are described from the prior snapshot so details survive after the position is gone. Retired `_describe_last_added`; replaced by `_describe_position(pos)`.
- **Persistence round-trip**: `position_id` written on export; restored on JSON and YAML import when present. Hand-authored YAML without the key silently gets a fresh UUID — no migration required.

## Test plan

- [x] `test_position_id_auto_generated` — non-empty string on default construction
- [x] `test_position_id_unique_per_instance` — two positions get different IDs
- [x] `test_position_id_explicit_restored` — explicit ID stored verbatim
- [x] `test_to_dict_includes_position_id` — `to_dict()` carries the ID
- [x] `test_add_position_returns_appended_position` — returned object is `positions[-1]`
- [x] `test_update_position_preserves_position_id` — ID stable across field mutation and option rebuild
- [x] `test_json_roundtrip_preserves_position_id` — save → load preserves all IDs
- [x] `test_yaml_import_without_position_id_gets_fresh_uuid` — hand-authored YAML gets a UUID
- [x] `TestSnapshot` (2 tests) — snapshot keys, empty portfolio
- [x] `TestTrackAdd` (4 tests) — single ADD id/details, bulk two entries with correct ids, none-None
- [x] `TestTrackRemove` (3 tests) — id survives removal, non-None, details describe original position
- [x] `TestTrackUpdate` (2 tests) — UPDATE logged, no spurious ADD/REMOVE

Gate: 993 passed, mypy clean (92 files), ruff clean, pylint 10.00/10, both notebooks execute headless.

🤖 Generated with [Claude Code](https://claude.com/claude-code)