### PR TITLE
refactor: break widgets/persistence cycle (#144) + extract shared helpers (#143)

### DIFF
--- a/deltadewa/analysis/candidate.py
+++ b/deltadewa/analysis/candidate.py
@@ -11,7 +11,7 @@ eliminating any duplicated pricing or payoff logic between the two callers.
 from __future__ import annotations
 
 from dataclasses import dataclass
-from datetime import timedelta
+from datetime import datetime, timedelta
 from typing import TYPE_CHECKING
 
 from deltadewa import constants as const
@@ -54,7 +54,7 @@ class CandidateMetrics:
 
 
 # ---------------------------------------------------------------------------
-# Internal helper
+# Internal helpers
 # ---------------------------------------------------------------------------
 
 
@@ -66,6 +66,47 @@ def _intrinsic_at_crash(strike: float, crash_spot: float) -> float:
 
     """
     return max(0.0, strike - crash_spot)
+
+
+def build_put_valuation(
+    spot: float,
+    strike: float,
+    maturity_date: datetime,
+    effective_vol: float,
+    portfolio: OptionPortfolio,
+) -> OptionValuation:
+    """Construct a put :class:`~deltadewa.valuation.OptionValuation`.
+
+    Centralises the nine-kwarg constructor that both
+    :func:`evaluate_candidate` and
+    :func:`~deltadewa.analysis.strike_ladder.strike_for_delta` need,
+    keeping exercise style, rate, and dividend wired from the portfolio
+    in one place.
+
+    Args:
+        spot: Current underlying spot price.
+        strike: Put strike price.
+        maturity_date: Option expiry date.
+        effective_vol: Implied volatility (annualised fraction); typically
+            ``portfolio.volatility`` or an explicit override.
+        portfolio: Supplies ``risk_free_rate``, ``dividend_yield``, and
+            ``default_exercise_style``.
+
+    Returns:
+        Configured :class:`~deltadewa.valuation.OptionValuation` ready
+        for ``.price()``, ``.delta()``, or ``.theta()`` calls.
+
+    """
+    return OptionValuation(
+        spot_price=spot,
+        strike_price=strike,
+        maturity_date=maturity_date,
+        volatility=effective_vol,
+        risk_free_rate=portfolio.risk_free_rate,
+        dividend_yield=portfolio.dividend_yield,
+        option_type=OptionType.PUT,
+        exercise_style=portfolio.default_exercise_style,
+    )
 
 
 # ---------------------------------------------------------------------------
@@ -115,15 +156,8 @@ def evaluate_candidate(
     maturity_date = portfolio.valuation_date + timedelta(
         days=round(maturity_years * const.DAYS_PER_YEAR),
     )
-    valuation = OptionValuation(
-        spot_price=spot,
-        strike_price=strike,
-        maturity_date=maturity_date,
-        volatility=effective_vol,
-        risk_free_rate=portfolio.risk_free_rate,
-        dividend_yield=portfolio.dividend_yield,
-        option_type=OptionType.PUT,
-        exercise_style=portfolio.default_exercise_style,
+    valuation = build_put_valuation(
+        spot, strike, maturity_date, effective_vol, portfolio
     )
 
     put_delta = valuation.delta()

--- a/deltadewa/analysis/sizing.py
+++ b/deltadewa/analysis/sizing.py
@@ -97,6 +97,30 @@ class HedgeSizingResult:
     meets_convexity_target: bool
 
 
+@dataclass(frozen=True)
+class UnitSizingResult:
+    """Return value of :func:`size_from_unit`.
+
+    Attributes:
+        contracts_needed: Minimum whole contracts to cover the required offset;
+            0 when ``per_contract_payoff`` is zero.
+        implied_annual_carry: ``contracts_needed * per_contract_carry``.
+        within_budget: ``True`` when ``implied_annual_carry <= carry_budget``.
+        carry_headroom: ``carry_budget - implied_annual_carry``; negative
+            means over-budget.
+        max_affordable_contracts: Most contracts the budget can support
+            (floor division); ``sys.maxsize`` when ``per_contract_carry``
+            is zero.
+
+    """
+
+    contracts_needed: int
+    implied_annual_carry: float
+    within_budget: bool
+    carry_headroom: float
+    max_affordable_contracts: int
+
+
 # ---------------------------------------------------------------------------
 # Pure-math core
 # ---------------------------------------------------------------------------
@@ -132,7 +156,7 @@ def size_from_unit(
     per_contract_payoff: float,
     per_contract_carry: float,
     carry_budget: float,
-) -> tuple[int, float, bool, float, int]:
+) -> UnitSizingResult:
     """Pure scalar sizing math — no pricing, no portfolio.
 
     Args:
@@ -164,12 +188,12 @@ def size_from_unit(
         else sys.maxsize
     )
 
-    return (
-        contracts_needed,
-        implied_annual_carry,
-        within_budget,
-        carry_headroom,
-        max_affordable,
+    return UnitSizingResult(
+        contracts_needed=contracts_needed,
+        implied_annual_carry=implied_annual_carry,
+        within_budget=within_budget,
+        carry_headroom=carry_headroom,
+        max_affordable_contracts=max_affordable,
     )
 
 
@@ -227,20 +251,14 @@ def size_hedge(
         vol=vol,
     )
 
-    (
-        contracts_needed,
-        implied_annual_carry,
-        within_budget,
-        carry_headroom,
-        max_affordable,
-    ) = size_from_unit(
+    sizing = size_from_unit(
         offset,
         metrics.per_contract_payoff,
         metrics.per_contract_carry,
         carry_budget,
     )
 
-    achieved_payoff = contracts_needed * metrics.per_contract_payoff
+    achieved_payoff = sizing.contracts_needed * metrics.per_contract_payoff
     achieved_convexity_pct = (
         achieved_payoff / book_notional * 100.0 if book_notional > 0.0 else 0.0
     )
@@ -257,11 +275,11 @@ def size_hedge(
         required_crash_offset=offset,
         per_contract_payoff=metrics.per_contract_payoff,
         per_contract_carry=metrics.per_contract_carry,
-        contracts_needed=contracts_needed,
-        implied_annual_carry=implied_annual_carry,
-        within_budget=within_budget,
-        carry_headroom=carry_headroom,
-        max_affordable_contracts=max_affordable,
+        contracts_needed=sizing.contracts_needed,
+        implied_annual_carry=sizing.implied_annual_carry,
+        within_budget=sizing.within_budget,
+        carry_headroom=sizing.carry_headroom,
+        max_affordable_contracts=sizing.max_affordable_contracts,
         achieved_convexity_pct=achieved_convexity_pct,
         meets_convexity_target=meets_convexity_target,
     )

--- a/deltadewa/analysis/strike_ladder.py
+++ b/deltadewa/analysis/strike_ladder.py
@@ -22,10 +22,12 @@ from typing import TYPE_CHECKING
 from scipy.optimize import brentq
 
 from deltadewa import constants as const
-from deltadewa.analysis.candidate import CandidateMetrics, evaluate_candidate
+from deltadewa.analysis.candidate import (
+    CandidateMetrics,
+    build_put_valuation,
+    evaluate_candidate,
+)
 from deltadewa.analysis.sizing import required_crash_offset, size_from_unit
-from deltadewa.constants import OptionType
-from deltadewa.valuation import OptionValuation
 
 if TYPE_CHECKING:
     from deltadewa.ips_config import IpsConfig
@@ -142,15 +144,8 @@ def strike_for_delta(
 
     def _put_delta_at(strike: float) -> float:
         """Compute put delta for *strike*, all other inputs fixed."""
-        v = OptionValuation(
-            spot_price=spot,
-            strike_price=strike,
-            maturity_date=maturity_date,
-            volatility=effective_vol,
-            risk_free_rate=portfolio.risk_free_rate,
-            dividend_yield=portfolio.dividend_yield,
-            option_type=OptionType.PUT,
-            exercise_style=portfolio.default_exercise_style,
+        v = build_put_valuation(
+            spot, strike, maturity_date, effective_vol, portfolio
         )
         return v.delta()
 
@@ -251,20 +246,14 @@ def build_strike_ladder(
             crash_pct=crash_pct,
             vol=vol,
         )
-        (
-            contracts_needed,
-            implied_annual_carry,
-            within_budget,
-            carry_headroom,
-            max_affordable,
-        ) = size_from_unit(
+        sizing = size_from_unit(
             offset,
             metrics.per_contract_payoff,
             metrics.per_contract_carry,
             carry_budget,
         )
         achieved_convexity_pct = (
-            contracts_needed
+            sizing.contracts_needed
             * metrics.per_contract_payoff
             / book_notional
             * 100.0
@@ -280,15 +269,17 @@ def build_strike_ladder(
                 maturity_years=maturity,
                 metrics=metrics,
                 required_crash_offset=offset,
-                contracts_needed=contracts_needed,
-                implied_annual_carry=implied_annual_carry,
+                contracts_needed=sizing.contracts_needed,
+                implied_annual_carry=sizing.implied_annual_carry,
                 carry_budget=carry_budget,
-                within_budget=within_budget,
-                carry_headroom=carry_headroom,
-                max_affordable_contracts=max_affordable,
+                within_budget=sizing.within_budget,
+                carry_headroom=sizing.carry_headroom,
+                max_affordable_contracts=sizing.max_affordable_contracts,
                 achieved_convexity_pct=achieved_convexity_pct,
                 meets_convexity=meets_convexity,
-                meets_target_within_budget=within_budget and meets_convexity,
+                meets_target_within_budget=(
+                    sizing.within_budget and meets_convexity
+                ),
             ),
         )
     return rungs

--- a/deltadewa/widgets/export_controls.py
+++ b/deltadewa/widgets/export_controls.py
@@ -4,10 +4,12 @@ This module provides mixin classes for export/import functionality
 in the deltadewa dashboard.
 """
 
+from __future__ import annotations
+
 from collections.abc import Callable
 from datetime import UTC, datetime
 from pathlib import Path
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 import ipywidgets as widgets
 from ipyfilechooser import FileChooser
@@ -15,9 +17,11 @@ from ipyfilechooser import FileChooser
 from deltadewa.config import (
     create_export_dir_widget as _create_export_dir_widget,
 )
-from deltadewa.persistence import PortfolioSerializer
 from deltadewa.portfolio.core import OptionPortfolio
 from deltadewa.reporting.audit import PortfolioLogger
+
+if TYPE_CHECKING:
+    from deltadewa.persistence import PortfolioSerializer
 
 
 class ExportControlsMixin:

--- a/deltadewa/widgets/portfolio_controls.py
+++ b/deltadewa/widgets/portfolio_controls.py
@@ -4,21 +4,25 @@ This module provides comprehensive widget controls for creating, editing,
 and managing option portfolios in the deltadewa dashboard.
 """
 
+from __future__ import annotations
+
 import datetime
 from collections.abc import Callable
 from datetime import datetime as dt
 from datetime import timedelta
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 import ipywidgets as widgets
 
 from deltadewa.constants import ExerciseStyle, OptionType
-from deltadewa.persistence import PortfolioSerializer
 from deltadewa.portfolio.core import OptionPortfolio
 from deltadewa.portfolio.position import OptionPosition
 from deltadewa.reporting import PortfolioLogger
 from deltadewa.widgets.export_controls import ExportControlsMixin
 from deltadewa.widgets.heatmap_controls import HeatmapControlsMixin
+
+if TYPE_CHECKING:
+    from deltadewa.persistence import PortfolioSerializer
 
 
 class PortfolioWidgets(ExportControlsMixin, HeatmapControlsMixin):

--- a/tests/test_analysis/test_candidate.py
+++ b/tests/test_analysis/test_candidate.py
@@ -2,11 +2,14 @@
 
 from __future__ import annotations
 
+import datetime
+
 import pytest
 
 from deltadewa.analysis.candidate import (
     CandidateMetrics,
     _intrinsic_at_crash,
+    build_put_valuation,
     evaluate_candidate,
 )
 from deltadewa.constants import ExerciseStyle
@@ -235,3 +238,59 @@ class TestCandidateContractSizeScaling:
         assert evaluate_candidate(p100, **kwargs).pct_otm == pytest.approx(
             evaluate_candidate(p50, **kwargs).pct_otm,
         )
+
+
+# ---------------------------------------------------------------------------
+# build_put_valuation
+# ---------------------------------------------------------------------------
+
+
+class TestBuildPutValuation:
+    """Tests for build_put_valuation."""
+
+    def test_returns_option_valuation(self) -> None:
+        """build_put_valuation returns an OptionValuation."""
+        from deltadewa.valuation import OptionValuation
+
+        portfolio = _make_spx_portfolio()
+        maturity_dt = datetime.datetime(2026, 10, 1, tzinfo=datetime.UTC)
+        v = build_put_valuation(5000.0, 4750.0, maturity_dt, 0.20, portfolio)
+        assert isinstance(v, OptionValuation)
+
+    def test_delta_is_negative(self) -> None:
+        """Put delta returned by the valuation is negative for an OTM put."""
+        portfolio = _make_spx_portfolio()
+        maturity_dt = datetime.datetime(2026, 10, 1, tzinfo=datetime.UTC)
+        v = build_put_valuation(5000.0, 4750.0, maturity_dt, 0.20, portfolio)
+        assert v.delta() < 0.0
+
+    def test_price_is_positive(self) -> None:
+        """Put price is a positive value."""
+        portfolio = _make_spx_portfolio()
+        maturity_dt = datetime.datetime(2026, 10, 1, tzinfo=datetime.UTC)
+        v = build_put_valuation(5000.0, 4750.0, maturity_dt, 0.20, portfolio)
+        assert v.price() > 0.0
+
+    def test_vol_override_changes_price(self) -> None:
+        """Higher vol produces a higher put price."""
+        portfolio = _make_spx_portfolio()
+        maturity_dt = datetime.datetime(2026, 10, 1, tzinfo=datetime.UTC)
+        v_low = build_put_valuation(
+            5000.0, 4750.0, maturity_dt, 0.15, portfolio
+        )
+        v_high = build_put_valuation(
+            5000.0, 4750.0, maturity_dt, 0.30, portfolio
+        )
+        assert v_high.price() > v_low.price()
+
+    def test_exercise_style_from_portfolio(self) -> None:
+        """build_put_valuation wires exercise_style from portfolio."""
+        from deltadewa.constants import ExerciseStyle
+
+        p_eu = _make_spx_portfolio(exercise_style=ExerciseStyle.EUROPEAN)
+        p_am = _make_spx_portfolio(exercise_style=ExerciseStyle.AMERICAN)
+        maturity_dt = datetime.datetime(2026, 10, 1, tzinfo=datetime.UTC)
+        # Both must price without error; American ≥ European for a put.
+        v_eu = build_put_valuation(5000.0, 4750.0, maturity_dt, 0.20, p_eu)
+        v_am = build_put_valuation(5000.0, 4750.0, maturity_dt, 0.20, p_am)
+        assert v_am.price() >= v_eu.price()

--- a/tests/test_analysis/test_sizing.py
+++ b/tests/test_analysis/test_sizing.py
@@ -8,6 +8,7 @@ import pytest
 
 from deltadewa.analysis.sizing import (
     HedgeSizingResult,
+    UnitSizingResult,
     required_crash_offset,
     size_from_unit,
     size_hedge,
@@ -122,66 +123,76 @@ class TestRequiredCrashOffset:
 class TestSizeFromUnit:
     """Tests for size_from_unit."""
 
-    def test_within_budget(self) -> None:
-        """Standard case: 80 contracts, carry within budget."""
-        contracts, carry, within, headroom, max_aff = size_from_unit(
+    def test_returns_unit_sizing_result(self) -> None:
+        """size_from_unit returns a UnitSizingResult instance."""
+        result = size_from_unit(
             required_offset=200_000.0,
             per_contract_payoff=2_500.0,
             per_contract_carry=3_000.0,
             carry_budget=500_000.0,
         )
-        assert contracts == 80  # ceil(200_000 / 2_500)
-        assert carry == pytest.approx(240_000.0)
-        assert within is True
-        assert headroom == pytest.approx(260_000.0)
-        assert max_aff == 166  # floor(500_000 / 3_000)
+        assert isinstance(result, UnitSizingResult)
+
+    def test_within_budget(self) -> None:
+        """Standard case: 80 contracts, carry within budget."""
+        r = size_from_unit(
+            required_offset=200_000.0,
+            per_contract_payoff=2_500.0,
+            per_contract_carry=3_000.0,
+            carry_budget=500_000.0,
+        )
+        assert r.contracts_needed == 80  # ceil(200_000 / 2_500)
+        assert r.implied_annual_carry == pytest.approx(240_000.0)
+        assert r.within_budget is True
+        assert r.carry_headroom == pytest.approx(260_000.0)
+        assert r.max_affordable_contracts == 166  # floor(500_000 / 3_000)
 
     def test_over_budget(self) -> None:
         """Large required offset pushes implied carry above budget."""
-        contracts, carry, within, headroom, max_aff = size_from_unit(
+        r = size_from_unit(
             required_offset=1_000_000.0,
             per_contract_payoff=2_500.0,
             per_contract_carry=3_000.0,
             carry_budget=100_000.0,
         )
-        assert contracts == 400  # ceil(1_000_000 / 2_500)
-        assert carry == pytest.approx(1_200_000.0)
-        assert within is False
-        assert headroom == pytest.approx(-1_100_000.0)
-        assert max_aff == 33  # floor(100_000 / 3_000)
+        assert r.contracts_needed == 400  # ceil(1_000_000 / 2_500)
+        assert r.implied_annual_carry == pytest.approx(1_200_000.0)
+        assert r.within_budget is False
+        assert r.carry_headroom == pytest.approx(-1_100_000.0)
+        assert r.max_affordable_contracts == 33  # floor(100_000 / 3_000)
 
     def test_zero_payoff_guard(self) -> None:
         """Zero payoff → contracts_needed is 0, no ZeroDivisionError."""
-        contracts, carry, within, headroom, _max_aff = size_from_unit(
+        r = size_from_unit(
             required_offset=100_000.0,
             per_contract_payoff=0.0,
             per_contract_carry=3_000.0,
             carry_budget=500_000.0,
         )
-        assert contracts == 0
-        assert carry == pytest.approx(0.0)
-        assert within is True
-        assert headroom == pytest.approx(500_000.0)
+        assert r.contracts_needed == 0
+        assert r.implied_annual_carry == pytest.approx(0.0)
+        assert r.within_budget is True
+        assert r.carry_headroom == pytest.approx(500_000.0)
 
     def test_zero_carry_guard(self) -> None:
-        """Zero carry → max_affordable is sys.maxsize, no ZeroDivisionError."""
-        _, _, _, _, max_aff = size_from_unit(
+        """Zero carry → max_affordable_contracts is sys.maxsize."""
+        r = size_from_unit(
             required_offset=100_000.0,
             per_contract_payoff=2_500.0,
             per_contract_carry=0.0,
             carry_budget=500_000.0,
         )
-        assert max_aff == sys.maxsize
+        assert r.max_affordable_contracts == sys.maxsize
 
     def test_exact_offset_no_rounding(self) -> None:
         """Required offset exactly divisible by payoff → no rounding up."""
-        contracts, *_ = size_from_unit(
+        r = size_from_unit(
             required_offset=250_000.0,
             per_contract_payoff=2_500.0,
             per_contract_carry=3_000.0,
             carry_budget=1_000_000.0,
         )
-        assert contracts == 100  # exact, no ceil effect
+        assert r.contracts_needed == 100  # exact, no ceil effect
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_analysis/test_strike_ladder.py
+++ b/tests/test_analysis/test_strike_ladder.py
@@ -346,7 +346,7 @@ class TestBuildStrikeLadder:
             crash_pct=crash_pct,
         )
         offset = required_crash_offset(book_notional, crash_pct, 20.0)
-        contracts, carry, within, headroom, _max = size_from_unit(
+        sizing = size_from_unit(
             offset,
             metrics.per_contract_payoff,
             metrics.per_contract_carry,
@@ -357,10 +357,12 @@ class TestBuildStrikeLadder:
         assert rung.metrics.per_contract_carry == pytest.approx(
             metrics.per_contract_carry,
         )
-        assert rung.contracts_needed == contracts
-        assert rung.implied_annual_carry == pytest.approx(carry)
-        assert rung.within_budget == within
-        assert rung.carry_headroom == pytest.approx(headroom)
+        assert rung.contracts_needed == sizing.contracts_needed
+        assert rung.implied_annual_carry == pytest.approx(
+            sizing.implied_annual_carry
+        )
+        assert rung.within_budget == sizing.within_budget
+        assert rung.carry_headroom == pytest.approx(sizing.carry_headroom)
 
     def test_no_solution_rung_skipped(self) -> None:
         """Unsolvable target_delta produces no rung — no raise."""


### PR DESCRIPTION
## Summary

- **#144 (R0401 cyclic-import):** `export_controls.py` and `portfolio_controls.py` top-imported `PortfolioSerializer` at module load time, creating a `deltadewa → widgets → persistence` cycle. Fixed with `from __future__ import annotations` + `TYPE_CHECKING` guard — matching the pattern already used in `sizing.py`, `candidate.py`, and `strike_ladder.py`. pylint no longer reports R0401.

- **#143 (R0801 duplicate-code):** Two genuine duplicates extracted:
  - `UnitSizingResult` frozen dataclass added to `sizing.py` as the return type of `size_from_unit`, replacing `tuple[int, float, bool, float, int]`. Eliminates the identical 12-line tuple-unpack in `size_hedge` and `build_strike_ladder`.
  - `build_put_valuation` extracted into `candidate.py` (the existing shared-helper module), removing the identical 9-kwarg `OptionValuation` constructor from `evaluate_candidate` and `_put_delta_at` in `strike_ladder.py`.
  - **Left as-is:** the `set_table_styles` td-border blocks in `dataframes.py` / `gradients.py`. They differ in `text-align` (`center` vs `right`) and padding (present vs absent) — intentional per-table CSS policy. A parameterised helper would add more code than it removes.

## Test plan

- [ ] `poetry run pytest` — 1000 passed (5 new tests for `build_put_valuation`)
- [ ] `poetry run mypy deltadewa` — 0 issues in 92 files
- [ ] `poetry run ruff check .` — clean
- [ ] `poetry run pylint deltadewa` — 10.00/10 (R0401 and R0801 resolved)
- [ ] `poetry run nbqa ruff monitor_dashboard.ipynb hedge_design.ipynb` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)