### PR TITLE
refactor: reduce complexity of the three chart/summary outliers

### DIFF
--- a/deltadewa/analysis/summary.py
+++ b/deltadewa/analysis/summary.py
@@ -1,11 +1,251 @@
 """Summary and insights mixin for portfolio analysis."""
 
-from typing import TYPE_CHECKING, Any
+from collections.abc import Callable
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Any, TypeVar
 
 import numpy as np
 
 if TYPE_CHECKING:
     from deltadewa.analysis._protocols import _AnalyzerProtocol
+    from deltadewa.portfolio.core import OptionPortfolio
+
+_T = TypeVar("_T")
+_Row = tuple[Callable[[_T], bool], Callable[[_T], list[str]]]
+
+
+def _resolve(context: _T, rows: tuple[_Row[_T], ...]) -> list[str]:
+    """Return the lines from the first row whose predicate matches."""
+    for predicate, formatter in rows:
+        if predicate(context):
+            return formatter(context)
+    return []
+
+
+_CAPITAL_ROWS: tuple[_Row[float], ...] = (
+    (
+        lambda net_debit: net_debit > 0,
+        lambda net_debit: [
+            f"  Net Debit: ${net_debit:,.2f} (capital required to implement)",
+        ],
+    ),
+    (
+        lambda _net_debit: True,
+        lambda net_debit: [
+            f"  Net Credit: ${-net_debit:,.2f} (capital received)",
+        ],
+    ),
+)
+
+_BREAKEVEN_ROWS: tuple[_Row[list[float]], ...] = (
+    (
+        bool,
+        lambda breakevens: [
+            "  Breakeven Points: "
+            + ", ".join(f"${be:.2f}" for be in breakevens),
+        ],
+    ),
+    (
+        lambda _breakevens: True,
+        lambda _breakevens: ["  Breakeven Points: None identified"],
+    ),
+)
+
+
+@dataclass(frozen=True)
+class _MaxLossContext:
+    """Parameters for formatting a max-loss line in either section."""
+
+    info: dict[str, Any]
+    unlimited_label: str
+    pct_basis: float
+    pct_phrase: str
+    show_pct: bool
+
+
+def _format_unlimited_max_loss(ctx: _MaxLossContext) -> list[str]:
+    """Format the max-loss line when loss is unlimited."""
+    return [f"  Max Loss: UNLIMITED ({ctx.unlimited_label})"]
+
+
+def _format_bounded_max_loss(ctx: _MaxLossContext) -> list[str]:
+    """Format the max-loss line and spot marker when loss is bounded."""
+    loss_line = f"  Max Loss: ${-ctx.info['max_loss']:,.2f}"
+    if ctx.show_pct:
+        loss_pct = (-ctx.info["max_loss"] / abs(ctx.pct_basis)) * 100
+        loss_line += f" ({loss_pct:.1f}% {ctx.pct_phrase})"
+    return [
+        loss_line,
+        f"    └─ Occurs at spot price: ${ctx.info['spot_at_max_loss']:.2f}",
+    ]
+
+
+_MAX_LOSS_ROWS: tuple[_Row[_MaxLossContext], ...] = (
+    (lambda ctx: bool(ctx.info["is_unlimited"]), _format_unlimited_max_loss),
+    (lambda _ctx: True, _format_bounded_max_loss),
+)
+
+
+def _format_max_loss(ctx: _MaxLossContext) -> list[str]:
+    """Dispatch max-loss formatting on the unlimited/bounded case."""
+    return _resolve(ctx, _MAX_LOSS_ROWS)
+
+
+@dataclass(frozen=True)
+class _MaxProfitContext:
+    """Parameters for formatting a max-profit line in either section."""
+
+    info: dict[str, Any]
+    unlimited_lines: list[str]
+    pct_basis: float
+    pct_phrase: str
+    show_pct: bool
+
+
+def _format_unlimited_max_profit(ctx: _MaxProfitContext) -> list[str]:
+    """Format the max-profit line(s) when profit is unlimited."""
+    return ctx.unlimited_lines
+
+
+def _format_bounded_max_profit(ctx: _MaxProfitContext) -> list[str]:
+    """Format the max-profit line and spot marker when profit is bounded."""
+    profit_line = f"  Max Profit: ${ctx.info['max_profit']:,.2f}"
+    if ctx.show_pct:
+        profit_pct = (ctx.info["max_profit"] / ctx.pct_basis) * 100
+        profit_line += f" ({profit_pct:.1f}% {ctx.pct_phrase})"
+    return [
+        profit_line,
+        f"    └─ Occurs at spot price: ${ctx.info['spot_at_max_profit']:.2f}",
+    ]
+
+
+_MAX_PROFIT_ROWS: tuple[_Row[_MaxProfitContext], ...] = (
+    (
+        lambda ctx: bool(ctx.info["is_unlimited"]),
+        _format_unlimited_max_profit,
+    ),
+    (lambda _ctx: True, _format_bounded_max_profit),
+)
+
+
+def _format_max_profit(ctx: _MaxProfitContext) -> list[str]:
+    """Dispatch max-profit formatting on the unlimited/bounded case."""
+    return _resolve(ctx, _MAX_PROFIT_ROWS)
+
+
+_TOTAL_UNLIMITED_PROFIT_ROWS: tuple[_Row[float], ...] = (
+    (
+        lambda underlying_quantity: underlying_quantity > 0,
+        lambda _underlying_quantity: [
+            "  Max Profit: UNLIMITED (long underlying position)",
+            "    └─ Profit increases with spot price",
+        ],
+    ),
+    (
+        lambda _underlying_quantity: True,
+        lambda _underlying_quantity: [
+            "  Max Profit: UNLIMITED",
+            "    └─ Profit increases with spot price",
+        ],
+    ),
+)
+
+
+def _format_capital_section(net_debit: float) -> list[str]:
+    """Format the capital-requirements section."""
+    return ["CAPITAL REQUIREMENTS:", *_resolve(net_debit, _CAPITAL_ROWS), ""]
+
+
+def _format_options_section(
+    analysis: dict[str, Any],
+    net_debit: float,
+) -> list[str]:
+    """Format the options-only risk/reward section."""
+    loss_ctx = _MaxLossContext(
+        info=analysis["max_loss_options"],
+        unlimited_label="naked short positions",
+        pct_basis=net_debit,
+        pct_phrase="of net debit",
+        show_pct=net_debit != 0,
+    )
+    profit_ctx = _MaxProfitContext(
+        info=analysis["max_profit_options"],
+        unlimited_lines=["  Max Profit: UNLIMITED"],
+        pct_basis=net_debit,
+        pct_phrase="return on net debit",
+        show_pct=net_debit > 0,
+    )
+    return [
+        "OPTIONS ONLY RISK/REWARD:",
+        *_format_max_loss(loss_ctx),
+        *_format_max_profit(profit_ctx),
+        *_resolve(analysis["breakeven_options"], _BREAKEVEN_ROWS),
+        "",
+    ]
+
+
+def _format_total_section(
+    portfolio: "OptionPortfolio",
+    analysis: dict[str, Any],
+) -> list[str]:
+    """Format the total-portfolio (options + underlying) section."""
+    max_loss_total = analysis["max_loss_total"]
+    portfolio_value = 0.0
+    if not max_loss_total["is_unlimited"]:
+        portfolio_value = portfolio.total_portfolio_value()
+
+    loss_ctx = _MaxLossContext(
+        info=max_loss_total,
+        unlimited_label="short underlying position",
+        pct_basis=portfolio_value,
+        pct_phrase="of portfolio value",
+        show_pct=portfolio_value > 0,
+    )
+    profit_ctx = _MaxProfitContext(
+        info=analysis["max_profit_total"],
+        unlimited_lines=_resolve(
+            portfolio.underlying_quantity,
+            _TOTAL_UNLIMITED_PROFIT_ROWS,
+        ),
+        pct_basis=portfolio_value,
+        pct_phrase="of portfolio value",
+        show_pct=portfolio_value > 0,
+    )
+    return [
+        "TOTAL PORTFOLIO RISK/REWARD (Options + Underlying):",
+        *_format_max_loss(loss_ctx),
+        *_format_max_profit(profit_ctx),
+        *_resolve(analysis["breakeven_total"], _BREAKEVEN_ROWS),
+        "",
+    ]
+
+
+def _format_probability_section(analysis: dict[str, Any]) -> list[str]:
+    """Format the probability-analysis section."""
+    prob = analysis["prob_profit"]
+    return [
+        "PROBABILITY ANALYSIS:",
+        f"  Chance of Profit: {prob * 100:.1f}%",
+        f"  Expected Value: ${analysis['expected_pnl']:,.2f} "
+        f"(probabilistic weighted average)",
+        "",
+    ]
+
+
+def _format_ratio_section(analysis: dict[str, Any]) -> list[str]:
+    """Format the risk/reward ratio line, if the ratio is meaningful."""
+    max_loss_opts = analysis["max_loss_options"]
+    max_profit_opts = analysis["max_profit_options"]
+    if (
+        not max_loss_opts["is_unlimited"]
+        and not max_profit_opts["is_unlimited"]
+        and max_loss_opts["max_loss"] < 0 < max_profit_opts["max_profit"]
+    ):
+        rr_ratio = max_profit_opts["max_profit"] / -max_loss_opts["max_loss"]
+        return [
+            f"RISK/REWARD RATIO: {rr_ratio:.2f}:1 (max profit to max loss)",
+        ]
+    return []
 
 
 class SummaryMixin:
@@ -158,7 +398,7 @@ class SummaryMixin:
 
         return insights
 
-    def format_risk_reward_summary(  # pylint: disable=R0912,R0915
+    def format_risk_reward_summary(
         self: "_AnalyzerProtocol",
         spot_range: np.ndarray[Any, np.dtype[Any]] | None = None,
     ) -> str:
@@ -172,145 +412,15 @@ class SummaryMixin:
 
         """
         analysis = self.risk_reward_analysis(spot_range)
-        portfolio_value = 0.0
-
-        lines = []
-        lines.append("=" * 80)
-        lines.append("PORTFOLIO RISK/REWARD ANALYSIS")
-        lines.append("=" * 80)
-        lines.append("")
-
-        # Capital Requirements
-        lines.append("CAPITAL REQUIREMENTS:")
         net_debit = analysis["net_debit"]
-        if net_debit > 0:
-            lines.append(
-                f"  Net Debit: ${net_debit:,.2f} "
-                f"(capital required to implement)",
-            )
-        else:
-            lines.append(f"  Net Credit: ${-net_debit:,.2f} (capital received)")
-        lines.append("")
 
-        # Options Only Risk/Reward
-        lines.append("OPTIONS ONLY RISK/REWARD:")
-        max_loss_opts = analysis["max_loss_options"]
-        max_profit_opts = analysis["max_profit_options"]
-
-        if max_loss_opts["is_unlimited"]:
-            lines.append("  Max Loss: UNLIMITED (naked short positions)")
-        else:
-            loss_line = f"  Max Loss: ${-max_loss_opts['max_loss']:,.2f}"
-            if net_debit != 0:
-                loss_pct = (-max_loss_opts["max_loss"] / abs(net_debit)) * 100
-                loss_line += f" ({loss_pct:.1f}% of net debit)"
-            lines.append(loss_line)
-            lines.append(
-                f"    └─ Occurs at spot price: $"
-                f"{max_loss_opts['spot_at_max_loss']:.2f}",
-            )
-
-        if max_profit_opts["is_unlimited"]:
-            lines.append("  Max Profit: UNLIMITED")
-        else:
-            profit_line = f"  Max Profit: ${max_profit_opts['max_profit']:,.2f}"
-            if net_debit > 0:
-                roi = (max_profit_opts["max_profit"] / net_debit) * 100
-                profit_line += f" ({roi:.1f}% return on net debit)"
-            lines.append(profit_line)
-            lines.append(
-                f"    └─ Occurs at spot price: $"
-                f"{max_profit_opts['spot_at_max_profit']:.2f}",
-            )
-
-        if analysis["breakeven_options"]:
-            breakevens_str = ", ".join(
-                [f"${be:.2f}" for be in analysis["breakeven_options"]],
-            )
-            lines.append(f"  Breakeven Points: {breakevens_str}")
-        else:
-            lines.append("  Breakeven Points: None identified")
-        lines.append("")
-
-        # Total Portfolio Risk/Reward
+        lines = ["=" * 80, "PORTFOLIO RISK/REWARD ANALYSIS", "=" * 80, ""]
+        lines.extend(_format_capital_section(net_debit))
+        lines.extend(_format_options_section(analysis, net_debit))
         if self.portfolio.underlying_quantity != 0:
-            lines.append("TOTAL PORTFOLIO RISK/REWARD (Options + Underlying):")
-            max_loss_total = analysis["max_loss_total"]
-            max_profit_total = analysis["max_profit_total"]
-
-            if max_loss_total["is_unlimited"]:
-                lines.append(
-                    "  Max Loss: UNLIMITED (short underlying position)",
-                )
-            else:
-                portfolio_value = self.portfolio.total_portfolio_value()
-                loss_line = f"  Max Loss: ${-max_loss_total['max_loss']:,.2f}"
-                if portfolio_value > 0:
-                    loss_pct = (
-                        -max_loss_total["max_loss"] / portfolio_value
-                    ) * 100
-                    loss_line += f" ({loss_pct:.1f}% of portfolio value)"
-                lines.append(loss_line)
-                lines.append(
-                    f"    └─ Occurs at spot price: $"
-                    f"{max_loss_total['spot_at_max_loss']:.2f}",
-                )
-
-            if max_profit_total["is_unlimited"]:
-                if self.portfolio.underlying_quantity > 0:
-                    lines.append(
-                        "  Max Profit: UNLIMITED (long underlying position)",
-                    )
-                else:
-                    lines.append("  Max Profit: UNLIMITED")
-                lines.append("    └─ Profit increases with spot price")
-            else:
-                profit_line = (
-                    f"  Max Profit: ${max_profit_total['max_profit']:,.2f}"
-                )
-                if portfolio_value > 0:
-                    profit_pct = (
-                        max_profit_total["max_profit"] / portfolio_value
-                    ) * 100
-                    profit_line += f" ({profit_pct:.1f}% of portfolio value)"
-                lines.append(profit_line)
-                lines.append(
-                    f"    └─ Occurs at spot price: $"
-                    f"{max_profit_total['spot_at_max_profit']:.2f}",
-                )
-
-            if analysis["breakeven_total"]:
-                breakevens_str = ", ".join(
-                    [f"${be:.2f}" for be in analysis["breakeven_total"]],
-                )
-                lines.append(f"  Breakeven Points: {breakevens_str}")
-            else:
-                lines.append("  Breakeven Points: None identified")
-            lines.append("")
-
-        # Probability Analysis
-        lines.append("PROBABILITY ANALYSIS:")
-        prob = analysis["prob_profit"]
-        lines.append(f"  Chance of Profit: {prob * 100:.1f}%")
-        lines.append(
-            f"  Expected Value: ${analysis['expected_pnl']:,.2f} "
-            f"(probabilistic weighted average)",
-        )
-        lines.append("")
-
-        # Risk/Reward Ratio
-        if (
-            not max_loss_opts["is_unlimited"]
-            and not max_profit_opts["is_unlimited"]
-            and max_loss_opts["max_loss"] < 0 < max_profit_opts["max_profit"]
-        ):
-            # Standard risk/reward ratio: profit potential to loss potential
-            rr_ratio = (
-                max_profit_opts["max_profit"] / -max_loss_opts["max_loss"]
-            )
-            lines.append(
-                f"RISK/REWARD RATIO: {rr_ratio:.2f}:1 (max profit to max loss)",
-            )
+            lines.extend(_format_total_section(self.portfolio, analysis))
+        lines.extend(_format_probability_section(analysis))
+        lines.extend(_format_ratio_section(analysis))
         lines.append("=" * 80)
 
         return "\n".join(lines)

--- a/deltadewa/visualization/_protocols.py
+++ b/deltadewa/visualization/_protocols.py
@@ -55,6 +55,98 @@ class _VisualizationProtocol(Protocol, Generic[PortfolioT]):
         title: str,
     ) -> None: ...
 
+    def _compute_time_to_maturity(self) -> float: ...
+
+    def _compute_pdf_overlay_and_percentiles(
+        self,
+        spot_range: np.ndarray[Any, np.dtype[Any]],
+        pnl_values: np.ndarray[Any, np.dtype[Any]],
+        current_spot: float,
+        time_to_maturity: float,
+    ) -> tuple[float, np.ndarray[Any, np.dtype[Any]], float, float]: ...
+
+    def _shade_probability_density(
+        self,
+        ax: Axes,
+        spot_range: np.ndarray[Any, np.dtype[Any]],
+        pdf_baseline: float,
+        pdf_plot_values: np.ndarray[Any, np.dtype[Any]],
+    ) -> None: ...
+
+    def _annotate_percentile_lines(
+        self,
+        ax: Axes,
+        is_5th_in_range: bool,
+        is_95th_in_range: bool,
+        spot_5th_percentile: float,
+        spot_95th_percentile: float,
+    ) -> None: ...
+
+    def _annotate_percentile_label(
+        self,
+        ax: Axes,
+        pct_label: str,
+        spot_value: float,
+        in_range: bool,
+        edge_spot: float,
+        y_positions: tuple[float, float],
+        side: str,
+    ) -> None: ...
+
+    def _shade_profit_loss_zones(
+        self,
+        ax: Axes,
+        spot_range: np.ndarray[Any, np.dtype[Any]],
+        pnl_values: np.ndarray[Any, np.dtype[Any]],
+    ) -> None: ...
+
+    def _annotate_current_spot_marker(
+        self,
+        ax: Axes,
+        current_spot: float,
+        pnl_values: np.ndarray[Any, np.dtype[Any]],
+    ) -> None: ...
+
+    def _annotate_breakevens(
+        self,
+        ax: Axes,
+        analysis: dict[str, Any],
+        be_key: str,
+        include_underlying: bool,
+    ) -> None: ...
+
+    def _annotate_max_loss(
+        self,
+        ax: Axes,
+        analysis: dict[str, Any],
+        ml_key: str,
+        spot_range_min: float,
+        spot_range_max: float,
+        pnl_values: np.ndarray[Any, np.dtype[Any]],
+    ) -> None: ...
+
+    def _annotate_max_profit(
+        self,
+        ax: Axes,
+        analysis: dict[str, Any],
+        mp_key: str,
+    ) -> None: ...
+
+    def _annotate_expected_value(
+        self,
+        ax: Axes,
+        analysis: dict[str, Any],
+        spot_range: np.ndarray[Any, np.dtype[Any]],
+        pnl_values: np.ndarray[Any, np.dtype[Any]],
+    ) -> None: ...
+
+    def _format_pnl_distribution_axes(
+        self,
+        ax: Axes,
+        include_underlying: bool,
+        current_spot: float,
+    ) -> None: ...
+
     # ThetaChartsMixin
     def _prepare_theta_data(
         self,

--- a/deltadewa/visualization/convenience.py
+++ b/deltadewa/visualization/convenience.py
@@ -6,11 +6,14 @@ OptionCharts methods for easier use.
 
 from __future__ import annotations
 
+from collections.abc import Callable
+from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any, overload
 
 import matplotlib.pyplot as plt
 import pandas as pd
 from matplotlib.axes import Axes
+from matplotlib.container import BarContainer
 from matplotlib.figure import Figure
 from matplotlib.ticker import FuncFormatter
 
@@ -135,7 +138,175 @@ def plot_theta_analysis(
     return charts.plot_theta_analysis(**kwargs)
 
 
-def plot_greeks_consolidated(  # pylint: disable=R0914,R0912,R0915
+def _set_axis_formatting(
+    ax: Axes,
+    title: str = "",
+    xaxis: bool = True,
+    yaxis: bool = True,
+    xint: float = 0,
+    yint: float = 0,
+) -> None:
+    """Draw the shared zero-line/title chrome used by consolidated panels."""
+    ax.grid(False)
+    if xaxis:
+        ax.axhline(y=yint, color=DEFAULT_PALETTE.axis, linewidth=1)
+    if yaxis:
+        ax.axvline(x=xint, color=DEFAULT_PALETTE.axis, linewidth=1)
+    ax.set_title(
+        title,
+        fontsize=11,
+        fontweight="bold",
+    )
+
+
+def _add_bar_value_labels(
+    ax: Axes,
+    bars: BarContainer,
+    values: list[float],
+) -> None:
+    """Add a numeric label beside each non-zero horizontal bar."""
+    for b, value in zip(bars, values, strict=False):
+        if value != 0:
+            label_x = value + (
+                0.05 * max(abs(v) for v in values) * (1 if value > 0 else -1)
+            )
+            ax.text(
+                label_x,
+                b.get_y() + b.get_height() / 2,
+                f"{value:.2f}",
+                ha="left" if value > 0 else "right",
+                va="center",
+                fontsize=8,
+            )
+
+
+@dataclass(frozen=True)
+class _GreekPanelStyle:
+    """Per-panel display options for a Greek contributors bar chart."""
+
+    xlabel: str | None = None
+    add_value_labels: bool = False
+    currency_format: bool = False
+    annotate_empty: bool = True
+
+
+def _draw_greek_contributors_panel(
+    ax: Axes,
+    df: pd.DataFrame,
+    column: str,
+    greek_name: str,
+    top_n: int,
+    style: _GreekPanelStyle,
+) -> None:
+    """Draw a top-N contributors bar panel for a single Greek column.
+
+    Called once per Greek (Delta, Gamma, Vega, Theta) from
+    ``plot_greeks_consolidated``; the per-panel differences (whether bars
+    get value labels, currency-formatted axis ticks, an explicit x-axis
+    label, and a "No data" placeholder when empty) are supplied by the
+    caller's ``style`` so this stays a single parameterised routine.
+    """
+    ax.patch.set_alpha(0.0)
+    df_sorted = df.copy()
+    df_sorted["abs_value"] = df_sorted[column].abs()
+    df_sorted = df_sorted.nlargest(top_n, "abs_value")
+
+    if len(df_sorted) == 0:
+        if style.annotate_empty:
+            _annotate_no_data(ax)
+        return
+
+    labels = [
+        f"{row['option_type'].upper()[:1]}{row['strike']:.0f}"
+        for _, row in df_sorted.iterrows()
+    ]
+    values = df_sorted[column].tolist()
+    colors_contrib = [
+        DEFAULT_PALETTE.positive if v > 0 else DEFAULT_PALETTE.negative
+        for v in values
+    ]
+
+    bars = ax.barh(labels, values, color=colors_contrib)
+    ax.set_xlabel(style.xlabel if style.xlabel is not None else greek_name)
+    yint, _ = ax.get_ylim()
+    _set_axis_formatting(
+        ax,
+        f"Top {top_n} {greek_name} Contributors",
+        yint=yint,
+    )
+    if style.currency_format:
+        ax.xaxis.set_major_formatter(FuncFormatter(format_currency_for_axis))
+
+    if style.add_value_labels:
+        _add_bar_value_labels(ax, bars, values)
+
+
+def _draw_value_by_dimension_panel(
+    ax: Axes,
+    df: pd.DataFrame,
+    groupby_column: str,
+    top_n: int,
+    title: str,
+    label_formatter: Callable[[Any], str],
+) -> None:
+    """Draw a top-N bar panel of summed position value by a dimension.
+
+    Called once per dimension (strike, maturity) from
+    ``plot_greeks_consolidated``.
+    """
+    ax.patch.set_alpha(0.0)
+    grouped = df.groupby(groupby_column)["position_value"].sum()
+    grouped = grouped.reindex(grouped.abs().nlargest(top_n).index)
+
+    if len(grouped) == 0:
+        _annotate_no_data(ax)
+        return
+
+    labels = [label_formatter(v) for v in grouped.index]
+    values = grouped.tolist()
+    colors_contrib = [
+        DEFAULT_PALETTE.positive if v > 0 else DEFAULT_PALETTE.negative
+        for v in values
+    ]
+
+    ax.barh(labels, values, color=colors_contrib)
+    ax.set_xlabel("Position Value")
+    yint, _ = ax.get_ylim()
+    _set_axis_formatting(ax, title, yint=yint)
+    ax.xaxis.set_major_formatter(FuncFormatter(format_currency_for_axis))
+
+
+def _draw_greeks_by_dimension_panel(
+    ax: Axes,
+    df: pd.DataFrame,
+    groupby_column: str,
+    title: str,
+    xlabel: str,
+) -> None:
+    """Draw a stacked Delta/Gamma bar panel grouped by a dimension.
+
+    Called once per dimension (strike, maturity) from
+    ``plot_greeks_consolidated``.
+    """
+    ax.patch.set_alpha(0.0)
+    greek_by_dimension = df.groupby(groupby_column).agg(
+        {"position_delta": "sum", "position_gamma": "sum"},
+    )
+
+    if len(greek_by_dimension) == 0:
+        _annotate_no_data(ax)
+        return
+
+    greek_by_dimension.plot(kind="bar", ax=ax, width=0.7)
+    ax.set_xlabel(xlabel)
+    ax.set_ylabel("Greek Value")
+    ax.legend(["Delta", "Gamma"], loc="best")
+    ax.tick_params(axis="x", rotation=0)
+    xint, _ = ax.get_xlim()
+    _set_axis_formatting(ax, title, xint=xint)
+
+
+def plot_greeks_consolidated(
     portfolio: OptionPortfolio | OptionPortfolioBase,
     top_n: int = 5,
     figsize: tuple[int, int] = (16, 10),
@@ -186,233 +357,87 @@ def plot_greeks_consolidated(  # pylint: disable=R0914,R0912,R0915
     fig, axes = plt.subplots(nrows, 2, figsize=figsize)
     fig.patch.set_alpha(0.0)
 
-    def _set_axis_formatting(
-        ax: Axes,
-        title: str = "",
-        xaxis: bool = True,
-        yaxis: bool = True,
-        xint: float = 0,
-        yint: float = 0,
-    ) -> None:
-        ax.grid(False)
-        if xaxis:
-            ax.axhline(y=yint, color=DEFAULT_PALETTE.axis, linewidth=1)
-        if yaxis:
-            ax.axvline(x=xint, color=DEFAULT_PALETTE.axis, linewidth=1)
-        ax.set_title(
-            title,
-            fontsize=11,
-            fontweight="bold",
-        )
-
     # Panel 1 & 2: Top Contributors for Delta and Gamma
     for idx, (greek_name, column_name) in enumerate(
         [("Delta", "position_delta"), ("Gamma", "position_gamma")],
     ):
-        ax = axes[0, idx]
-        ax.patch.set_alpha(0.0)
-
-        # Calculate top contributors
-        df_sorted = df.copy()
-        df_sorted["abs_value"] = df_sorted[column_name].abs()
-        df_sorted = df_sorted.nlargest(top_n, "abs_value")
-
-        if len(df_sorted) > 0:
-            # Create labels combining symbol, type, strike
-            labels = [
-                f"{row['option_type'].upper()[:1]}{row['strike']:.0f}"
-                for _, row in df_sorted.iterrows()
-            ]
-            values = df_sorted[column_name].tolist()
-            colors_contrib = [
-                DEFAULT_PALETTE.positive if v > 0 else DEFAULT_PALETTE.negative
-                for v in values
-            ]
-
-            bars = ax.barh(labels, values, color=colors_contrib)
-            ax.set_xlabel(greek_name)
-            yint, _ = ax.get_ylim()
-            _set_axis_formatting(
-                ax,
-                f"Top {top_n} {greek_name} Contributors",
-                yint=yint,
-            )
-
-            # Add value labels
-            for b, value in zip(bars, values, strict=False):
-                if value != 0:
-                    label_x = value + (
-                        0.05
-                        * max(abs(v) for v in values)
-                        * (1 if value > 0 else -1)
-                    )
-                    ax.text(
-                        label_x,
-                        b.get_y() + b.get_height() / 2,
-                        f"{value:.2f}",
-                        ha="left" if value > 0 else "right",
-                        va="center",
-                        fontsize=8,
-                    )
-        else:
-            _annotate_no_data(ax)
+        _draw_greek_contributors_panel(
+            axes[0, idx],
+            df,
+            column_name,
+            greek_name,
+            top_n,
+            _GreekPanelStyle(add_value_labels=True),
+        )
 
     # Detailed panels (if requested)
     # Panel 3: Top Vega Contributors
-    ax = axes[1, 0]
-    ax.patch.set_alpha(0.0)
-    df_sorted = df.copy()
-    df_sorted["abs_value"] = df_sorted["position_vega"].abs()
-    df_sorted = df_sorted.nlargest(top_n, "abs_value")
-
-    if len(df_sorted) > 0:
-        labels = [
-            f"{row['option_type'].upper()[:1]}{row['strike']:.0f}"
-            for _, row in df_sorted.iterrows()
-        ]
-        values = df_sorted["position_vega"].tolist()
-        colors_contrib = [
-            DEFAULT_PALETTE.positive if v > 0 else DEFAULT_PALETTE.negative
-            for v in values
-        ]
-
-        bars = ax.barh(labels, values, color=colors_contrib)
-        ax.set_xlabel("Vega")
-        yint, _ = ax.get_ylim()
-        _set_axis_formatting(ax, f"Top {top_n} Vega Contributors", yint=yint)
-
-    else:
-        _annotate_no_data(ax)
+    _draw_greek_contributors_panel(
+        axes[1, 0],
+        df,
+        "position_vega",
+        "Vega",
+        top_n,
+        _GreekPanelStyle(),
+    )
 
     # Panel 4: Top Theta Contributors
-    ax = axes[1, 1]
-    ax.patch.set_alpha(0.0)
-    df_sorted = df.copy()
-    df_sorted["abs_value"] = df_sorted["position_theta"].abs()
-    df_sorted = df_sorted.nlargest(top_n, "abs_value")
-
-    if len(df_sorted) > 0:
-        labels = [
-            f"{row['option_type'].upper()[:1]}{row['strike']:.0f}"
-            for _, row in df_sorted.iterrows()
-        ]
-        values = df_sorted["position_theta"].tolist()
-        colors_contrib = [
-            DEFAULT_PALETTE.positive if v > 0 else DEFAULT_PALETTE.negative
-            for v in values
-        ]
-
-        bars = ax.barh(labels, values, color=colors_contrib)
-        ax.set_xlabel("Theta ($/day)")
-        yint, _ = ax.get_ylim()
-        _set_axis_formatting(ax, f"Top {top_n} Theta Contributors", yint=yint)
-        ax.xaxis.set_major_formatter(FuncFormatter(format_currency_for_axis))
+    _draw_greek_contributors_panel(
+        axes[1, 1],
+        df,
+        "position_theta",
+        "Theta",
+        top_n,
+        _GreekPanelStyle(
+            xlabel="Theta ($/day)",
+            currency_format=True,
+            annotate_empty=False,
+        ),
+    )
 
     # Panel 5: Value by Strike
-    ax = axes[2, 0]
-    ax.patch.set_alpha(0.0)
-    df_sorted = df.copy()
-
-    # Group by strike and sum position values
-    strike_values = df_sorted.groupby("strike")["position_value"].sum()
-    strike_values = strike_values.reindex(
-        strike_values.abs().nlargest(top_n).index,
+    _draw_value_by_dimension_panel(
+        axes[2, 0],
+        df,
+        "strike",
+        top_n,
+        f"Top {top_n} Position Values by Strike",
+        lambda strike: f"{strike:.2f}",
     )
-
-    if len(strike_values) > 0:
-        labels = [f"{strike:.2f}" for strike in strike_values.index]
-        values = strike_values.tolist()
-        colors_contrib = [
-            DEFAULT_PALETTE.positive if v > 0 else DEFAULT_PALETTE.negative
-            for v in values
-        ]
-
-        bars = ax.barh(labels, values, color=colors_contrib)
-        ax.set_xlabel("Position Value")
-        yint, _ = ax.get_ylim()
-        _set_axis_formatting(
-            ax,
-            f"Top {top_n} Position Values by Strike",
-            yint=yint,
-        )
-        ax.xaxis.set_major_formatter(FuncFormatter(format_currency_for_axis))
-    else:
-        _annotate_no_data(ax)
 
     # Panel 6: Value by Maturity
-    ax = axes[2, 1]
-    ax.patch.set_alpha(0.0)
-    df_sorted = df.copy()
-    df_sorted["maturity_label"] = pd.to_datetime(
-        df_sorted["maturity"],
+    df_maturity = df.copy()
+    df_maturity["maturity_label"] = pd.to_datetime(
+        df_maturity["maturity"],
     ).dt.strftime("%Y-%m-%d")
-
-    # Group by maturity and sum position values
-    maturity_values = df_sorted.groupby("maturity_label")[
-        "position_value"
-    ].sum()
-    maturity_values = maturity_values.reindex(
-        maturity_values.abs().nlargest(top_n).index,
+    _draw_value_by_dimension_panel(
+        axes[2, 1],
+        df_maturity,
+        "maturity_label",
+        top_n,
+        f"Top {top_n} Position Values by Maturity",
+        str,
     )
-
-    if len(maturity_values) > 0:
-        labels = list(maturity_values.index)
-        values = maturity_values.tolist()
-        colors_contrib = [
-            DEFAULT_PALETTE.positive if v > 0 else DEFAULT_PALETTE.negative
-            for v in values
-        ]
-
-        bars = ax.barh(labels, values, color=colors_contrib)
-        ax.set_xlabel("Position Value")
-        yint, _ = ax.get_ylim()
-        _set_axis_formatting(
-            ax,
-            f"Top {top_n} Position Values by Maturity",
-            yint=yint,
-        )
-        ax.xaxis.set_major_formatter(FuncFormatter(format_currency_for_axis))
-    else:
-        _annotate_no_data(ax)
 
     # Panel 7: Greeks by Strike
-    ax = axes[3, 0]
-    ax.patch.set_alpha(0.0)
-    greek_by_strike = df.groupby("strike").agg(
-        {"position_delta": "sum", "position_gamma": "sum"},
+    _draw_greeks_by_dimension_panel(
+        axes[3, 0],
+        df,
+        "strike",
+        "Greeks by Strike",
+        "Strike Price",
     )
 
-    if len(greek_by_strike) > 0:
-        greek_by_strike.plot(kind="bar", ax=ax, width=0.7)
-        ax.set_xlabel("Strike Price")
-        ax.set_ylabel("Greek Value")
-        ax.legend(["Delta", "Gamma"], loc="best")
-        ax.tick_params(axis="x", rotation=0)
-        xint, _ = ax.get_xlim()
-        _set_axis_formatting(ax, "Greeks by Strike", xint=xint)
-
-    else:
-        _annotate_no_data(ax)
-
     # Panel 8: Greeks by Maturity
-    ax = axes[3, 1]
-    ax.patch.set_alpha(0.0)
     df["maturity_label"] = pd.to_datetime(df["maturity"]).dt.strftime(
         "%Y-%m-%d",
     )
-    greek_by_maturity = df.groupby("maturity_label").agg(
-        {"position_delta": "sum", "position_gamma": "sum"},
+    _draw_greeks_by_dimension_panel(
+        axes[3, 1],
+        df,
+        "maturity_label",
+        "Greeks by Maturity",
+        "Maturity Date",
     )
-
-    if len(greek_by_maturity) > 0:
-        greek_by_maturity.plot(kind="bar", ax=ax, width=0.7)
-        ax.set_xlabel("Maturity Date")
-        ax.set_ylabel("Greek Value")
-        ax.legend(["Delta", "Gamma"], loc="best")
-        ax.tick_params(axis="x", rotation=0)
-        xint, _ = ax.get_xlim()
-        _set_axis_formatting(ax, "Greeks by Maturity", xint=xint)
-    else:
-        _annotate_no_data(ax)
 
     return fig

--- a/deltadewa/visualization/pnl_charts.py
+++ b/deltadewa/visualization/pnl_charts.py
@@ -121,7 +121,7 @@ class PnLChartsMixin:
         plt.tight_layout()
         return fig
 
-    def plot_pnl_distribution_with_metrics(  # pylint: disable=R0914,R0912,R0915
+    def plot_pnl_distribution_with_metrics(
         self: "_VisualizationProtocol[Any]",
         spot_range_pct: float = 100.0,
         num_points: int = 1000,
@@ -168,14 +168,11 @@ class PnLChartsMixin:
         # Generate spot price range
         # Note: spot_range_pct is symmetric ± percentage (e.g., 100 means 0% to
         # 200%)
-        # Convert to spot_min_pct and spot_max_pct for generate_spot_range
         current_spot = self.portfolio.spot_price
-        spot_min_pct = 100 - spot_range_pct
-        spot_max_pct = 100 + spot_range_pct
         spot_range = generate_spot_range(
             spot_price=current_spot,
-            spot_min_pct=spot_min_pct,
-            spot_max_pct=spot_max_pct,
+            spot_min_pct=100 - spot_range_pct,
+            spot_max_pct=100 + spot_range_pct,
             num_points=num_points,
         )
 
@@ -189,8 +186,9 @@ class PnLChartsMixin:
         # CRITICAL: Pass spot_range=None to allow comprehensive range check for
         # max loss/profit
         # The visualization uses spot_range only for the chart display
-        analyzer = PortfolioAnalyzer(self.portfolio)
-        analysis = analyzer.risk_reward_analysis(spot_range=None)
+        analysis = PortfolioAnalyzer(self.portfolio).risk_reward_analysis(
+            spot_range=None,
+        )
 
         # Use pre-calculated Monte Carlo expected value if available to ensure
         # consistency between the main analysis and the chart visualization
@@ -210,8 +208,118 @@ class PnLChartsMixin:
         fig.patch.set_alpha(0.0)
         ax.patch.set_alpha(0.0)
 
-        # Calculate probability density function for spot prices at maturity
-        # Use the nearest maturity date for time horizon
+        time_to_maturity = self._compute_time_to_maturity()
+        (
+            pdf_baseline,
+            pdf_plot_values,
+            spot_5th_percentile,
+            spot_95th_percentile,
+        ) = self._compute_pdf_overlay_and_percentiles(
+            spot_range,
+            pnl_values,
+            current_spot,
+            time_to_maturity,
+        )
+        self._shade_probability_density(
+            ax,
+            spot_range,
+            pdf_baseline,
+            pdf_plot_values,
+        )
+
+        # Determine visible range bounds
+        spot_range_min = spot_range.min()
+        spot_range_max = spot_range.max()
+        is_5th_in_range = (
+            spot_range_min <= spot_5th_percentile <= spot_range_max
+        )
+        is_95th_in_range = (
+            spot_range_min <= spot_95th_percentile <= spot_range_max
+        )
+        self._annotate_percentile_lines(
+            ax,
+            is_5th_in_range,
+            is_95th_in_range,
+            spot_5th_percentile,
+            spot_95th_percentile,
+        )
+
+        ax.plot(
+            spot_range,
+            pnl_values,
+            linewidth=3,
+            color=DEFAULT_PALETTE.medium_background,
+            label="P&L at Maturity",
+            zorder=3,
+        )
+
+        # Add annotations for percentile levels
+        y_annotation = pnl_values.max() * 0.95
+        y_mid = (pnl_values.max() + pnl_values.min()) / 2
+        self._annotate_percentile_label(
+            ax,
+            "5%",
+            spot_5th_percentile,
+            is_5th_in_range,
+            spot_range_min,
+            (y_annotation, y_mid),
+            "left",
+        )
+        self._annotate_percentile_label(
+            ax,
+            "95%",
+            spot_95th_percentile,
+            is_95th_in_range,
+            spot_range_max,
+            (y_annotation, y_mid),
+            "right",
+        )
+
+        self._shade_profit_loss_zones(ax, spot_range, pnl_values)
+        self._annotate_current_spot_marker(ax, current_spot, pnl_values)
+
+        self._annotate_breakevens(
+            ax,
+            analysis,
+            "breakeven_total" if include_underlying else "breakeven_options",
+            include_underlying,
+        )
+
+        self._annotate_max_loss(
+            ax,
+            analysis,
+            "max_loss_total" if include_underlying else "max_loss_options",
+            spot_range_min,
+            spot_range_max,
+            pnl_values,
+        )
+
+        self._annotate_max_profit(
+            ax,
+            analysis,
+            (
+                "max_profit_total"
+                if include_underlying
+                else "max_profit_options"
+            ),
+        )
+
+        self._annotate_expected_value(ax, analysis, spot_range, pnl_values)
+
+        self._format_pnl_distribution_axes(
+            ax,
+            include_underlying,
+            current_spot,
+        )
+
+        # Return figure
+        plt.tight_layout()
+        return fig
+
+    def _compute_time_to_maturity(
+        self: "_VisualizationProtocol[Any]",
+    ) -> float:
+        """Compute years to nearest position maturity, else 30-day default."""
         if self.portfolio.positions:
             min_maturity = min(
                 pos.option.maturity_date for pos in self.portfolio.positions
@@ -220,13 +328,23 @@ class PnLChartsMixin:
                 1,
                 (min_maturity - self.portfolio.valuation_date).days,
             )
-            time_to_maturity = days_to_maturity / const.DAYS_PER_YEAR
-        else:
-            time_to_maturity = (
-                const.CALENDAR_DAYS_PER_MONTH / const.DAYS_PER_YEAR
-            )  # Default to 30 days
+            return float(days_to_maturity / const.DAYS_PER_YEAR)
+        # Default to 30 days
+        return const.CALENDAR_DAYS_PER_MONTH / const.DAYS_PER_YEAR
 
-        # Calculate log-normal PDF for terminal spot prices (GBM assumption)
+    def _compute_pdf_overlay_and_percentiles(
+        self: "_VisualizationProtocol[Any]",
+        spot_range: np.ndarray[Any, np.dtype[Any]],
+        pnl_values: np.ndarray[Any, np.dtype[Any]],
+        current_spot: float,
+        time_to_maturity: float,
+    ) -> tuple[float, np.ndarray[Any, np.dtype[Any]], float, float]:
+        """Compute the terminal-spot PDF overlay and 5th/95th percentiles.
+
+        Returns the PDF baseline and scaled plot values (for shading under
+        the P&L curve) plus the 5th and 95th percentile spot prices, using
+        log-normal (GBM) parameters.
+        """
         volatility = self.portfolio.volatility
         risk_free_rate = self.portfolio.risk_free_rate
         dividend_yield = self.portfolio.dividend_yield
@@ -239,22 +357,43 @@ class PnLChartsMixin:
         )
         sigma = volatility * np.sqrt(time_to_maturity)
 
-        # Calculate PDF values
+        # Calculate PDF values, scaled to fit the full height of the chart
         pdf_values = (1 / (spot_range * sigma * np.sqrt(2 * np.pi))) * np.exp(
             -((np.log(spot_range) - mu) ** 2) / (2 * sigma**2),
         )
-
-        # Scale PDF to fit full height of chart
-        pnl_range = pnl_values.max() - pnl_values.min()
-        pdf_height = pnl_range  # Full height
-
-        # Normalize PDF to this height
+        pdf_height = pnl_values.max() - pnl_values.min()
         pdf_scaled = (pdf_values / pdf_values.max()) * pdf_height
-
-        # Position PDF at bottom of chart
         pdf_baseline = pnl_values.min()
         pdf_plot_values = pdf_baseline + pdf_scaled
 
+        # Calculate 5th and 95th percentile spot prices (90% confidence
+        # interval) using the analytical log-normal inverse CDF
+        try:
+            z_5th = stats.norm.ppf(0.05)
+            z_95th = stats.norm.ppf(0.95)
+        except ImportError:
+            # Fallback standard-normal quantile approximation
+            z_5th = -1.6449
+            z_95th = 1.6449
+
+        spot_5th_percentile = np.exp(mu + sigma * z_5th)
+        spot_95th_percentile = np.exp(mu + sigma * z_95th)
+
+        return (
+            pdf_baseline,
+            pdf_plot_values,
+            spot_5th_percentile,
+            spot_95th_percentile,
+        )
+
+    def _shade_probability_density(
+        self: "_VisualizationProtocol[Any]",
+        ax: Axes,
+        spot_range: np.ndarray[Any, np.dtype[Any]],
+        pdf_baseline: float,
+        pdf_plot_values: np.ndarray[Any, np.dtype[Any]],
+    ) -> None:
+        """Shade the terminal-spot probability density under the P&L curve."""
         # Plot PDF on MAIN axis with zorder=1 (behind other elements)
         ax.fill_between(
             spot_range,
@@ -265,43 +404,15 @@ class PnLChartsMixin:
             zorder=1,
         )
 
-        # Calculate 5th and 95th percentile spot prices (90% confidence
-        # interval)
-        # Using analytical log-normal distribution (inverse CDF)
-        # For log-normal with parameters mu and sigma:
-        # percentile_p = exp(mu + sigma * z_p) where z_p is the standard normal
-        # quantile
-        try:
-            z_5th = stats.norm.ppf(
-                0.05,
-            )  # Standard normal quantile for 5th percentile
-            z_95th = stats.norm.ppf(
-                0.95,
-            )  # Standard normal quantile for 95th percentile
-        except ImportError:
-            # Fallback to approximation if scipy not available
-            # Using inverse error function approximation for standard normal
-            # quantiles
-            # z_0.05 ≈ -1.645, z_0.95 ≈ 1.645
-            z_5th = -1.6449
-            z_95th = 1.6449
-
-        spot_5th_percentile = np.exp(mu + sigma * z_5th)
-        spot_95th_percentile = np.exp(mu + sigma * z_95th)
-
-        # Determine visible range bounds
-        spot_range_min = spot_range.min()
-        spot_range_max = spot_range.max()
-
-        # Check if percentiles are within visible range
-        is_5th_in_range = (
-            spot_range_min <= spot_5th_percentile <= spot_range_max
-        )
-        is_95th_in_range = (
-            spot_range_min <= spot_95th_percentile <= spot_range_max
-        )
-
-        # Add vertical dashed lines for percentiles only if in range
+    def _annotate_percentile_lines(
+        self: "_VisualizationProtocol[Any]",
+        ax: Axes,
+        is_5th_in_range: bool,
+        is_95th_in_range: bool,
+        spot_5th_percentile: float,
+        spot_95th_percentile: float,
+    ) -> None:
+        """Draw vertical dashed lines at the 5th/95th percentile spots."""
         if is_5th_in_range:
             ax.axvline(
                 spot_5th_percentile,
@@ -323,104 +434,80 @@ class PnLChartsMixin:
                 label="95% Probability Level",
             )
 
-        ax.plot(
-            spot_range,
-            pnl_values,
-            linewidth=3,
-            color=DEFAULT_PALETTE.medium_background,
-            label="P&L at Maturity",
-            zorder=3,
+    def _annotate_percentile_label(
+        self: "_VisualizationProtocol[Any]",
+        ax: Axes,
+        pct_label: str,
+        spot_value: float,
+        in_range: bool,
+        edge_spot: float,
+        y_positions: tuple[float, float],
+        side: str,
+    ) -> None:
+        """Label a percentile spot in-range, or point to it from the edge.
+
+        Args:
+            ax: Matplotlib axes.
+            pct_label: e.g. "5%" or "95%".
+            spot_value: The percentile spot price.
+            in_range: Whether spot_value falls within the visible x-range.
+            edge_spot: Chart edge to anchor the out-of-range callout to.
+            y_positions: (y_annotation, y_mid) — text-box Y position for the
+                in-range case, callout Y position for the out-of-range case.
+            side: "left" or "right" — edge/arrow direction to use.
+
+        """
+        y_annotation, y_mid = y_positions
+        if in_range:
+            ax.text(
+                spot_value,
+                y_annotation,
+                f"{pct_label} @ ${spot_value:,.0f}",
+                ha="center",
+                va="top",
+                fontsize=9,
+                color=DEFAULT_PALETTE.dark_background,
+                fontweight="bold",
+                bbox={
+                    "boxstyle": "round,pad=0.3",
+                    "facecolor": DEFAULT_PALETTE.white,
+                    "edgecolor": DEFAULT_PALETTE.dark_background,
+                    "alpha": 0.8,
+                },
+            )
+            return
+
+        offset = (30, 0) if side == "left" else (-30, 0)
+        ax.annotate(
+            f"{pct_label}\n${spot_value:,.0f}",
+            xy=(edge_spot, y_mid),
+            xytext=offset,
+            textcoords="offset points",
+            fontsize=9,
+            color=DEFAULT_PALETTE.dark_background,
+            fontweight="bold",
+            ha=side,
+            va="center",
+            bbox={
+                "boxstyle": "round,pad=0.3",
+                "facecolor": DEFAULT_PALETTE.white,
+                "edgecolor": DEFAULT_PALETTE.dark_background,
+                "alpha": 0.8,
+            },
+            arrowprops={
+                "arrowstyle": "<-",
+                "color": DEFAULT_PALETTE.dark_background,
+                "lw": 1.5,
+            },
         )
 
-        # Add annotations for percentile levels
-        y_annotation = pnl_values.max() * 0.95
-        y_mid = (pnl_values.max() + pnl_values.min()) / 2
-
-        if is_5th_in_range:
-            ax.text(
-                spot_5th_percentile,
-                y_annotation,
-                f"5% @ ${spot_5th_percentile:,.0f}",
-                ha="center",
-                va="top",
-                fontsize=9,
-                color=DEFAULT_PALETTE.dark_background,
-                fontweight="bold",
-                bbox={
-                    "boxstyle": "round,pad=0.3",
-                    "facecolor": DEFAULT_PALETTE.white,
-                    "edgecolor": DEFAULT_PALETTE.dark_background,
-                    "alpha": 0.8,
-                },
-            )
-        else:
-            # 5th percentile is below visible range - show arrow on left edge
-            ax.annotate(
-                f"5%\n${spot_5th_percentile:,.0f}",
-                xy=(spot_range_min, y_mid),
-                xytext=(30, 0),
-                textcoords="offset points",
-                fontsize=9,
-                color=DEFAULT_PALETTE.dark_background,
-                fontweight="bold",
-                ha="left",
-                va="center",
-                bbox={
-                    "boxstyle": "round,pad=0.3",
-                    "facecolor": DEFAULT_PALETTE.white,
-                    "edgecolor": DEFAULT_PALETTE.dark_background,
-                    "alpha": 0.8,
-                },
-                arrowprops={
-                    "arrowstyle": "<-",
-                    "color": DEFAULT_PALETTE.dark_background,
-                    "lw": 1.5,
-                },
-            )
-
-        if is_95th_in_range:
-            ax.text(
-                spot_95th_percentile,
-                y_annotation,
-                f"95% @ ${spot_95th_percentile:,.0f}",
-                ha="center",
-                va="top",
-                fontsize=9,
-                color=DEFAULT_PALETTE.dark_background,
-                fontweight="bold",
-                bbox={
-                    "boxstyle": "round,pad=0.3",
-                    "facecolor": DEFAULT_PALETTE.white,
-                    "edgecolor": DEFAULT_PALETTE.dark_background,
-                    "alpha": 0.8,
-                },
-            )
-        else:
-            # 95th percentile is above visible range - show arrow on right edge
-            ax.annotate(
-                f"95%\n${spot_95th_percentile:,.0f}",
-                xy=(spot_range_max, y_mid),
-                xytext=(-30, 0),
-                textcoords="offset points",
-                fontsize=9,
-                color=DEFAULT_PALETTE.dark_background,
-                fontweight="bold",
-                ha="right",
-                va="center",
-                bbox={
-                    "boxstyle": "round,pad=0.3",
-                    "facecolor": DEFAULT_PALETTE.white,
-                    "edgecolor": DEFAULT_PALETTE.dark_background,
-                    "alpha": 0.8,
-                },
-                arrowprops={
-                    "arrowstyle": "<-",
-                    "color": DEFAULT_PALETTE.dark_background,
-                    "lw": 1.5,
-                },
-            )
-
-        # Add profit/loss zones with fill_between
+    def _shade_profit_loss_zones(
+        self: "_VisualizationProtocol[Any]",
+        ax: Axes,
+        spot_range: np.ndarray[Any, np.dtype[Any]],
+        pnl_values: np.ndarray[Any, np.dtype[Any]],
+    ) -> None:
+        """Shade profit (P&L >= 0) and loss (P&L < 0) zones under the curve."""
         ax.fill_between(
             spot_range,
             pnl_values,
@@ -440,7 +527,13 @@ class PnLChartsMixin:
             label="Loss Zone",
         )
 
-        # Add zero line and current spot marker
+    def _annotate_current_spot_marker(
+        self: "_VisualizationProtocol[Any]",
+        ax: Axes,
+        current_spot: float,
+        pnl_values: np.ndarray[Any, np.dtype[Any]],
+    ) -> None:
+        """Draw the zero line, current-spot line, and its label."""
         ax.axhline(
             0,
             color=DEFAULT_PALETTE.black,
@@ -473,172 +566,56 @@ class PnLChartsMixin:
             },
         )
 
-        # Annotate break-even points
-        be_key = (
-            "breakeven_total" if include_underlying else "breakeven_options"
-        )
-        if analysis.get(be_key):
-            for i, be in enumerate(analysis[be_key]):
-                be_pnl = self.portfolio.calculate_pnl_at_expiry(
-                    be,
-                    include_underlying=include_underlying,
-                )
-                # Add vertical dashed line at break-even
-                ax.axvline(
-                    be,
-                    color=DEFAULT_PALETTE.medium_grey,
-                    linestyle="--",
-                    linewidth=1.5,
-                    alpha=0.6,
-                    zorder=2,
-                )
+    def _annotate_breakevens(
+        self: "_VisualizationProtocol[Any]",
+        ax: Axes,
+        analysis: dict[str, Any],
+        be_key: str,
+        include_underlying: bool,
+    ) -> None:
+        """Mark break-even points with a diamond, line, and $-value label."""
+        if not analysis.get(be_key):
+            return
+        for i, be in enumerate(analysis[be_key]):
+            be_pnl = self.portfolio.calculate_pnl_at_expiry(
+                be,
+                include_underlying=include_underlying,
+            )
+            # Add vertical dashed line at break-even
+            ax.axvline(
+                be,
+                color=DEFAULT_PALETTE.medium_grey,
+                linestyle="--",
+                linewidth=1.5,
+                alpha=0.6,
+                zorder=2,
+            )
 
-                # Plot marker
-                ax.plot(
-                    be,
-                    be_pnl,
-                    marker="D",
-                    markersize=12,
-                    markeredgewidth=2,
-                    markerfacecolor=DEFAULT_PALETTE.yellow,
-                    markeredgecolor=DEFAULT_PALETTE.black,
-                    zorder=5,
-                )
-                # Add annotation
-                ax.annotate(
-                    f"BE ${be:.2f}",
-                    xy=(be, be_pnl),
-                    xytext=(0, 30 if i % 2 == 0 else -40),
-                    textcoords="offset points",
-                    fontsize=10,
-                    fontweight="bold",
-                    ha="center",
-                    bbox={
-                        "boxstyle": "round,pad=0.5",
-                        "facecolor": DEFAULT_PALETTE.yellow,
-                        "alpha": 0.7,
-                        "edgecolor": DEFAULT_PALETTE.black,
-                    },
-                    arrowprops={
-                        "arrowstyle": "->",
-                        "connectionstyle": "arc3,rad=0",
-                        "lw": 1.5,
-                    },
-                )
-
-        # Annotate maximum loss
-        ml_key = "max_loss_total" if include_underlying else "max_loss_options"
-        max_loss_info = analysis[ml_key]
-        if not max_loss_info["is_unlimited"]:
-            ml_spot = max_loss_info["spot_at_max_loss"]
-            ml_val = max_loss_info["max_loss"]
-
-            # Check if max loss spot is within visible range
-            is_ml_in_range = spot_range_min <= ml_spot <= spot_range_max
-
-            if is_ml_in_range:
-                # Plot marker at actual location
-                ax.plot(
-                    ml_spot,
-                    ml_val,
-                    marker="v",
-                    markersize=15,
-                    markeredgewidth=2,
-                    markerfacecolor=DEFAULT_PALETTE.negative,
-                    markeredgecolor=DEFAULT_PALETTE.negative,
-                    zorder=5,
-                )
-                # Add annotation
-                ax.annotate(
-                    f"ML ${ml_val:,.0f}",
-                    xy=(ml_spot, ml_val),
-                    xytext=(0, -50),
-                    textcoords="offset points",
-                    fontsize=10,
-                    fontweight="bold",
-                    ha="center",
-                    bbox={
-                        "boxstyle": "round,pad=0.5",
-                        "facecolor": DEFAULT_PALETTE.negative_faded,
-                        "alpha": 0.8,
-                        "edgecolor": DEFAULT_PALETTE.negative,
-                    },
-                    arrowprops={
-                        "arrowstyle": "->",
-                        "connectionstyle": "arc3,rad=0",
-                        "lw": 1.5,
-                    },
-                )
-            else:
-                # Max loss is outside visible range - show arrow at edge
-                if ml_spot < spot_range_min:
-                    edge_spot = spot_range_min
-                    edge_pnl = pnl_values[0]
-                    arrow_direction = "<-"
-                    text_offset = (40, -30)
-                    ha = "left"
-                else:
-                    edge_spot = spot_range_max
-                    edge_pnl = pnl_values[-1]
-                    arrow_direction = "<-"
-                    text_offset = (-40, -30)
-                    ha = "right"
-
-                ax.annotate(
-                    f"ML ${ml_val:,.0f} @ ${ml_spot:,.0f}",
-                    xy=(edge_spot, edge_pnl),
-                    xytext=text_offset,
-                    textcoords="offset points",
-                    fontsize=10,
-                    fontweight="bold",
-                    ha=ha,
-                    bbox={
-                        "boxstyle": "round,pad=0.5",
-                        "facecolor": DEFAULT_PALETTE.negative_faded,
-                        "alpha": 0.8,
-                        "edgecolor": DEFAULT_PALETTE.negative,
-                    },
-                    arrowprops={
-                        "arrowstyle": arrow_direction,
-                        "connectionstyle": "arc3,rad=0",
-                        "lw": 1.5,
-                        "color": DEFAULT_PALETTE.negative,
-                    },
-                )
-
-        # Annotate maximum profit
-        mp_key = (
-            "max_profit_total" if include_underlying else "max_profit_options"
-        )
-        max_profit_info = analysis[mp_key]
-        if not max_profit_info["is_unlimited"]:
-            mp_spot = max_profit_info["spot_at_max_profit"]
-            mp_val = max_profit_info["max_profit"]
             # Plot marker
             ax.plot(
-                mp_spot,
-                mp_val,
-                marker="^",
-                markersize=15,
+                be,
+                be_pnl,
+                marker="D",
+                markersize=12,
                 markeredgewidth=2,
-                markerfacecolor=DEFAULT_PALETTE.negative,
-                markeredgecolor=DEFAULT_PALETTE.positive,
+                markerfacecolor=DEFAULT_PALETTE.yellow,
+                markeredgecolor=DEFAULT_PALETTE.black,
                 zorder=5,
             )
             # Add annotation
             ax.annotate(
-                f"MP ${mp_val:,.0f}",
-                xy=(mp_spot, mp_val),
-                xytext=(0, 50),
+                f"BE ${be:.2f}",
+                xy=(be, be_pnl),
+                xytext=(0, 30 if i % 2 == 0 else -40),
                 textcoords="offset points",
                 fontsize=10,
                 fontweight="bold",
                 ha="center",
                 bbox={
                     "boxstyle": "round,pad=0.5",
-                    "facecolor": DEFAULT_PALETTE.positive_faded,
-                    "alpha": 0.8,
-                    "edgecolor": DEFAULT_PALETTE.positive,
+                    "facecolor": DEFAULT_PALETTE.yellow,
+                    "alpha": 0.7,
+                    "edgecolor": DEFAULT_PALETTE.black,
                 },
                 arrowprops={
                     "arrowstyle": "->",
@@ -647,48 +624,198 @@ class PnLChartsMixin:
                 },
             )
 
-        # Annotate expected value
-        expected_pnl = analysis.get("expected_pnl", 0)
-        if expected_pnl is not None:
-            # Find the spot price closest to the expected value on P&L curve
-            idx_closest = np.argmin(np.abs(pnl_values - expected_pnl))
-            ev_spot = spot_range[idx_closest]
-            ev_pnl = pnl_values[idx_closest]
+    def _annotate_max_loss(
+        self: "_VisualizationProtocol[Any]",
+        ax: Axes,
+        analysis: dict[str, Any],
+        ml_key: str,
+        spot_range_min: float,
+        spot_range_max: float,
+        pnl_values: np.ndarray[Any, np.dtype[Any]],
+    ) -> None:
+        """Mark the maximum-loss point, or point to it if off-chart."""
+        max_loss_info = analysis[ml_key]
+        if max_loss_info["is_unlimited"]:
+            return
 
-            # Plot marker
+        ml_spot = max_loss_info["spot_at_max_loss"]
+        ml_val = max_loss_info["max_loss"]
+
+        # Check if max loss spot is within visible range
+        is_ml_in_range = spot_range_min <= ml_spot <= spot_range_max
+
+        if is_ml_in_range:
+            # Plot marker at actual location
             ax.plot(
-                ev_spot,
-                ev_pnl,
-                marker="*",
-                markersize=20,
+                ml_spot,
+                ml_val,
+                marker="v",
+                markersize=15,
                 markeredgewidth=2,
-                markerfacecolor="gold",
-                markeredgecolor="orange",
+                markerfacecolor=DEFAULT_PALETTE.negative,
+                markeredgecolor=DEFAULT_PALETTE.negative,
                 zorder=5,
             )
             # Add annotation
             ax.annotate(
-                f"EV ${expected_pnl:,.0f}",
-                xy=(ev_spot, ev_pnl),
-                xytext=(50, 20),
+                f"ML ${ml_val:,.0f}",
+                xy=(ml_spot, ml_val),
+                xytext=(0, -50),
                 textcoords="offset points",
                 fontsize=10,
                 fontweight="bold",
                 ha="center",
                 bbox={
                     "boxstyle": "round,pad=0.5",
-                    "facecolor": DEFAULT_PALETTE.orange_faded,
+                    "facecolor": DEFAULT_PALETTE.negative_faded,
                     "alpha": 0.8,
-                    "edgecolor": "orange",
+                    "edgecolor": DEFAULT_PALETTE.negative,
                 },
                 arrowprops={
                     "arrowstyle": "->",
-                    "connectionstyle": "arc3,rad=0.2",
+                    "connectionstyle": "arc3,rad=0",
                     "lw": 1.5,
                 },
             )
+            return
 
-        # Format axes and labels
+        # Max loss is outside visible range - show arrow at edge
+        if ml_spot < spot_range_min:
+            edge_spot = spot_range_min
+            edge_pnl = pnl_values[0]
+            text_offset = (40, -30)
+            ha = "left"
+        else:
+            edge_spot = spot_range_max
+            edge_pnl = pnl_values[-1]
+            text_offset = (-40, -30)
+            ha = "right"
+
+        ax.annotate(
+            f"ML ${ml_val:,.0f} @ ${ml_spot:,.0f}",
+            xy=(edge_spot, edge_pnl),
+            xytext=text_offset,
+            textcoords="offset points",
+            fontsize=10,
+            fontweight="bold",
+            ha=ha,
+            bbox={
+                "boxstyle": "round,pad=0.5",
+                "facecolor": DEFAULT_PALETTE.negative_faded,
+                "alpha": 0.8,
+                "edgecolor": DEFAULT_PALETTE.negative,
+            },
+            arrowprops={
+                "arrowstyle": "<-",
+                "connectionstyle": "arc3,rad=0",
+                "lw": 1.5,
+                "color": DEFAULT_PALETTE.negative,
+            },
+        )
+
+    def _annotate_max_profit(
+        self: "_VisualizationProtocol[Any]",
+        ax: Axes,
+        analysis: dict[str, Any],
+        mp_key: str,
+    ) -> None:
+        """Mark the maximum-profit point on the P&L curve."""
+        max_profit_info = analysis[mp_key]
+        if max_profit_info["is_unlimited"]:
+            return
+
+        mp_spot = max_profit_info["spot_at_max_profit"]
+        mp_val = max_profit_info["max_profit"]
+        # Plot marker
+        ax.plot(
+            mp_spot,
+            mp_val,
+            marker="^",
+            markersize=15,
+            markeredgewidth=2,
+            markerfacecolor=DEFAULT_PALETTE.negative,
+            markeredgecolor=DEFAULT_PALETTE.positive,
+            zorder=5,
+        )
+        # Add annotation
+        ax.annotate(
+            f"MP ${mp_val:,.0f}",
+            xy=(mp_spot, mp_val),
+            xytext=(0, 50),
+            textcoords="offset points",
+            fontsize=10,
+            fontweight="bold",
+            ha="center",
+            bbox={
+                "boxstyle": "round,pad=0.5",
+                "facecolor": DEFAULT_PALETTE.positive_faded,
+                "alpha": 0.8,
+                "edgecolor": DEFAULT_PALETTE.positive,
+            },
+            arrowprops={
+                "arrowstyle": "->",
+                "connectionstyle": "arc3,rad=0",
+                "lw": 1.5,
+            },
+        )
+
+    def _annotate_expected_value(
+        self: "_VisualizationProtocol[Any]",
+        ax: Axes,
+        analysis: dict[str, Any],
+        spot_range: np.ndarray[Any, np.dtype[Any]],
+        pnl_values: np.ndarray[Any, np.dtype[Any]],
+    ) -> None:
+        """Mark the expected-value point closest to it on the P&L curve."""
+        expected_pnl = analysis.get("expected_pnl", 0)
+        if expected_pnl is None:
+            return
+
+        # Find the spot price closest to the expected value on P&L curve
+        idx_closest = np.argmin(np.abs(pnl_values - expected_pnl))
+        ev_spot = spot_range[idx_closest]
+        ev_pnl = pnl_values[idx_closest]
+
+        # Plot marker
+        ax.plot(
+            ev_spot,
+            ev_pnl,
+            marker="*",
+            markersize=20,
+            markeredgewidth=2,
+            markerfacecolor="gold",
+            markeredgecolor="orange",
+            zorder=5,
+        )
+        # Add annotation
+        ax.annotate(
+            f"EV ${expected_pnl:,.0f}",
+            xy=(ev_spot, ev_pnl),
+            xytext=(50, 20),
+            textcoords="offset points",
+            fontsize=10,
+            fontweight="bold",
+            ha="center",
+            bbox={
+                "boxstyle": "round,pad=0.5",
+                "facecolor": DEFAULT_PALETTE.orange_faded,
+                "alpha": 0.8,
+                "edgecolor": "orange",
+            },
+            arrowprops={
+                "arrowstyle": "->",
+                "connectionstyle": "arc3,rad=0.2",
+                "lw": 1.5,
+            },
+        )
+
+    def _format_pnl_distribution_axes(
+        self: "_VisualizationProtocol[Any]",
+        ax: Axes,
+        include_underlying: bool,
+        current_spot: float,
+    ) -> None:
+        """Apply axis labels, title, grid, and currency/pct tick formatters."""
         ax.set_xlabel(
             "Spot Price at Maturity ($)",
             fontsize=13,
@@ -726,10 +853,6 @@ class PnLChartsMixin:
             which="major",
             pad=8,
         )  # Add padding for two-line labels
-
-        # Return figure
-        plt.tight_layout()
-        return fig
 
     def _plot_pnl_panel(
         self: "_VisualizationProtocol[Any]",

--- a/tests/test_analysis/test_risk_reward.py
+++ b/tests/test_analysis/test_risk_reward.py
@@ -262,3 +262,333 @@ class TestRiskRewardMixin:
         assert "net_debit" in analysis
         assert "max_loss_options" in analysis
         assert "max_profit_options" in analysis
+
+
+class TestFormatRiskRewardSummaryCharacterization:
+    """Golden-string tests pinning format_risk_reward_summary's exact
+    output, so its case-dispatch refactor can be verified as
+    output-identical. `risk_reward_analysis` is deterministic (Monte
+    Carlo uses `random_seed=42` by default), so these compare full
+    strings rather than substrings.
+    """
+
+    def test_long_call_options_only(self) -> None:
+        """Bounded loss (with % of net debit), unlimited profit, no
+        total section: net_debit > 0 so the loss line gets a pct
+        suffix; profit is unlimited so no risk/reward ratio line.
+        """
+        portfolio = OptionPortfolio(spot_price=100.0, volatility=0.3)
+        portfolio.add_position(
+            strike_price=100.0,
+            maturity_date=datetime.now(tz=UTC) + timedelta(days=30),
+            quantity=1,
+            option_type=OptionType.CALL,
+        )
+        analyzer = PortfolioAnalyzer(portfolio)
+
+        summary = analyzer.format_risk_reward_summary()
+
+        expected = "\n".join(
+            [
+                "=" * 80,
+                "PORTFOLIO RISK/REWARD ANALYSIS",
+                "=" * 80,
+                "",
+                "CAPITAL REQUIREMENTS:",
+                "  Net Debit: $363.32 (capital required to implement)",
+                "",
+                "OPTIONS ONLY RISK/REWARD:",
+                "  Max Loss: $363.32 (100.0% of net debit)",
+                "    └─ Occurs at spot price: $0.01",
+                "  Max Profit: UNLIMITED",
+                "  Breakeven Points: $103.69",
+                "",
+                "PROBABILITY ANALYSIS:",
+                "  Chance of Profit: 33.9%",
+                "  Expected Value: $1.25 (probabilistic weighted average)",
+                "",
+                "=" * 80,
+            ],
+        )
+        assert summary == expected
+
+    def test_naked_short_call_net_credit(self) -> None:
+        """Unlimited loss ('naked short positions'), bounded profit
+        with no pct suffix since net_debit < 0 (net credit).
+        """
+        portfolio = OptionPortfolio(spot_price=100.0, volatility=0.3)
+        portfolio.add_position(
+            strike_price=110.0,
+            maturity_date=datetime.now(tz=UTC) + timedelta(days=30),
+            quantity=-1,
+            option_type=OptionType.CALL,
+        )
+        analyzer = PortfolioAnalyzer(portfolio)
+
+        summary = analyzer.format_risk_reward_summary()
+
+        expected = "\n".join(
+            [
+                "=" * 80,
+                "PORTFOLIO RISK/REWARD ANALYSIS",
+                "=" * 80,
+                "",
+                "CAPITAL REQUIREMENTS:",
+                "  Net Credit: $66.74 (capital received)",
+                "",
+                "OPTIONS ONLY RISK/REWARD:",
+                "  Max Loss: UNLIMITED (naked short positions)",
+                "  Max Profit: $66.74",
+                "    └─ Occurs at spot price: $0.01",
+                "  Breakeven Points: $113.72",
+                "",
+                "PROBABILITY ANALYSIS:",
+                "  Chance of Profit: 87.9%",
+                "  Expected Value: $-1.03 (probabilistic weighted average)",
+                "",
+                "=" * 80,
+            ],
+        )
+        assert summary == expected
+
+    def test_covered_call_with_long_underlying(self) -> None:
+        """Underlying present: exercises both total-section unlimited
+        labels together. The short call makes max_loss_total unlimited
+        via the naked-short-call check (not the underlying sign) yet
+        the printed label is still 'short underlying position' —
+        that's an existing quirk of the current code, pinned as-is.
+        max_profit_total is unlimited via the long underlying position.
+        """
+        portfolio = OptionPortfolio(
+            spot_price=100.0,
+            volatility=0.3,
+            underlying_quantity=100.0,
+        )
+        maturity = datetime.now(tz=UTC) + timedelta(days=30)
+        portfolio.add_position(
+            strike_price=95.0,
+            maturity_date=maturity,
+            quantity=1,
+            option_type=OptionType.PUT,
+        )
+        portfolio.add_position(
+            strike_price=110.0,
+            maturity_date=maturity,
+            quantity=-1,
+            option_type=OptionType.CALL,
+        )
+        analyzer = PortfolioAnalyzer(portfolio)
+
+        summary = analyzer.format_risk_reward_summary()
+
+        expected = "\n".join(
+            [
+                "=" * 80,
+                "PORTFOLIO RISK/REWARD ANALYSIS",
+                "=" * 80,
+                "",
+                "CAPITAL REQUIREMENTS:",
+                "  Net Debit: $65.27 (capital required to implement)",
+                "",
+                "OPTIONS ONLY RISK/REWARD:",
+                "  Max Loss: UNLIMITED (naked short positions)",
+                "  Max Profit: $9,433.73 (14452.8% return on net debit)",
+                "    └─ Occurs at spot price: $0.01",
+                "  Breakeven Points: $97.00",
+                "",
+                "TOTAL PORTFOLIO RISK/REWARD (Options + Underlying):",
+                "  Max Loss: UNLIMITED (short underlying position)",
+                "  Max Profit: UNLIMITED (long underlying position)",
+                "    └─ Profit increases with spot price",
+                "  Breakeven Points: $103.69",
+                "",
+                "PROBABILITY ANALYSIS:",
+                "  Chance of Profit: 47.1%",
+                "  Expected Value: $39.32 (probabilistic weighted average)",
+                "",
+                "=" * 80,
+            ],
+        )
+        assert summary == expected
+
+    def test_short_underlying_only_quirk_case(self) -> None:
+        """Short underlying alone: max_loss_total is unlimited, so
+        `portfolio_value` (used for the total section's '% of
+        portfolio value' suffixes) is never assigned — max_profit_total
+        is bounded but its line has no pct suffix as a result. This is
+        an existing quirk of the current code, pinned as-is.
+        """
+        portfolio = OptionPortfolio(
+            spot_price=100.0,
+            volatility=0.3,
+            underlying_quantity=-50.0,
+        )
+        analyzer = PortfolioAnalyzer(portfolio)
+
+        summary = analyzer.format_risk_reward_summary()
+
+        expected = "\n".join(
+            [
+                "=" * 80,
+                "PORTFOLIO RISK/REWARD ANALYSIS",
+                "=" * 80,
+                "",
+                "CAPITAL REQUIREMENTS:",
+                "  Net Credit: $0.00 (capital received)",
+                "",
+                "OPTIONS ONLY RISK/REWARD:",
+                "  Max Loss: $-0.00",
+                "    └─ Occurs at spot price: $0.01",
+                "  Max Profit: $0.00",
+                "    └─ Occurs at spot price: $0.01",
+                "  Breakeven Points: None identified",
+                "",
+                "TOTAL PORTFOLIO RISK/REWARD (Options + Underlying):",
+                "  Max Loss: UNLIMITED (short underlying position)",
+                "  Max Profit: $4,999.50",
+                "    └─ Occurs at spot price: $0.01",
+                "  Breakeven Points: $100.00, $100.34",
+                "",
+                "PROBABILITY ANALYSIS:",
+                "  Chance of Profit: 50.0%",
+                "  Expected Value: $-19.80 (probabilistic weighted average)",
+                "",
+                "=" * 80,
+            ],
+        )
+        assert summary == expected
+
+    def test_protective_put_with_long_underlying_and_ratio(self) -> None:
+        """Long underlying with a protective put: max_loss_total is
+        bounded (so the '% of portfolio value' suffix *does* show on
+        the loss line here), max_profit_total is unlimited via the
+        long underlying. Options loss/profit are both bounded, which
+        also exercises the risk/reward ratio section.
+        """
+        portfolio = OptionPortfolio(
+            spot_price=100.0,
+            volatility=0.3,
+            underlying_quantity=100.0,
+        )
+        portfolio.add_position(
+            strike_price=95.0,
+            maturity_date=datetime.now(tz=UTC) + timedelta(days=30),
+            quantity=1,
+            option_type=OptionType.PUT,
+        )
+        analyzer = PortfolioAnalyzer(portfolio)
+
+        summary = analyzer.format_risk_reward_summary()
+
+        expected = "\n".join(
+            [
+                "=" * 80,
+                "PORTFOLIO RISK/REWARD ANALYSIS",
+                "=" * 80,
+                "",
+                "CAPITAL REQUIREMENTS:",
+                "  Net Debit: $132.01 (capital required to implement)",
+                "",
+                "OPTIONS ONLY RISK/REWARD:",
+                "  Max Loss: $132.01 (100.0% of net debit)",
+                "    └─ Occurs at spot price: $97.00",
+                "  Max Profit: $9,366.99 (7095.7% return on net debit)",
+                "    └─ Occurs at spot price: $0.01",
+                "  Breakeven Points: $97.00",
+                "",
+                "TOTAL PORTFOLIO RISK/REWARD (Options + Underlying):",
+                "  Max Loss: $632.01 (6.2% of portfolio value)",
+                "    └─ Occurs at spot price: $0.01",
+                "  Max Profit: UNLIMITED (long underlying position)",
+                "    └─ Profit increases with spot price",
+                "  Breakeven Points: $103.69",
+                "",
+                "PROBABILITY ANALYSIS:",
+                "  Chance of Profit: 44.1%",
+                "  Expected Value: $40.35 (probabilistic weighted average)",
+                "",
+                "RISK/REWARD RATIO: 70.96:1 (max profit to max loss)",
+                "=" * 80,
+            ],
+        )
+        assert summary == expected
+
+    def test_call_spread_net_credit_both_unlimited(self) -> None:
+        """Short-strike-lower / long-strike-higher call spread: the
+        naked short leg makes both loss and profit read as unlimited
+        (profit unlimited comes from the long call leg), net_debit < 0.
+        """
+        maturity = datetime.now(tz=UTC) + timedelta(days=30)
+        portfolio = OptionPortfolio(spot_price=100.0, volatility=0.3)
+        portfolio.add_position(
+            strike_price=110.0,
+            maturity_date=maturity,
+            quantity=-1,
+            option_type=OptionType.CALL,
+        )
+        portfolio.add_position(
+            strike_price=120.0,
+            maturity_date=maturity,
+            quantity=1,
+            option_type=OptionType.CALL,
+        )
+        analyzer = PortfolioAnalyzer(portfolio)
+
+        summary = analyzer.format_risk_reward_summary()
+
+        expected = "\n".join(
+            [
+                "=" * 80,
+                "PORTFOLIO RISK/REWARD ANALYSIS",
+                "=" * 80,
+                "",
+                "CAPITAL REQUIREMENTS:",
+                "  Net Credit: $60.16 (capital received)",
+                "",
+                "OPTIONS ONLY RISK/REWARD:",
+                "  Max Loss: UNLIMITED (naked short positions)",
+                "  Max Profit: UNLIMITED",
+                "  Breakeven Points: $113.72",
+                "",
+                "PROBABILITY ANALYSIS:",
+                "  Chance of Profit: 88.1%",
+                "  Expected Value: $2.20 (probabilistic weighted average)",
+                "",
+                "=" * 80,
+            ],
+        )
+        assert summary == expected
+
+    def test_empty_portfolio(self) -> None:
+        """Empty portfolio: net_debit is 0 (credit branch), no
+        breakevens, no total section, no ratio section.
+        """
+        portfolio = OptionPortfolio(spot_price=100.0)
+        analyzer = PortfolioAnalyzer(portfolio)
+
+        summary = analyzer.format_risk_reward_summary()
+
+        expected = "\n".join(
+            [
+                "=" * 80,
+                "PORTFOLIO RISK/REWARD ANALYSIS",
+                "=" * 80,
+                "",
+                "CAPITAL REQUIREMENTS:",
+                "  Net Credit: $0.00 (capital received)",
+                "",
+                "OPTIONS ONLY RISK/REWARD:",
+                "  Max Loss: $-0.00",
+                "    └─ Occurs at spot price: $0.01",
+                "  Max Profit: $0.00",
+                "    └─ Occurs at spot price: $0.01",
+                "  Breakeven Points: None identified",
+                "",
+                "PROBABILITY ANALYSIS:",
+                "  Chance of Profit: 100.0%",
+                "  Expected Value: $0.00 (probabilistic weighted average)",
+                "",
+                "=" * 80,
+            ],
+        )
+        assert summary == expected

--- a/tests/test_visualization/test_integration.py
+++ b/tests/test_visualization/test_integration.py
@@ -114,6 +114,64 @@ class TestIntegration:
         assert fig is not None
         plt.close(fig)
 
+    def test_convenience_plot_greeks_consolidated_figure_structure(
+        self,
+    ) -> None:
+        """Test panel structure: 8 axes with the expected titles/xlabels.
+
+        Uses a multi-strike, multi-maturity portfolio so every panel
+        (per-Greek contributors, value-by-strike/maturity, Greeks-by-
+        strike/maturity) has data to render rather than a "No data"
+        placeholder.
+        """
+        portfolio = OptionPortfolio(spot_price=100.0)
+        maturity1 = datetime.now(tz=UTC) + timedelta(days=30)
+        maturity2 = datetime.now(tz=UTC) + timedelta(days=60)
+
+        portfolio.add_position(
+            strike_price=100.0,
+            maturity_date=maturity1,
+            quantity=1,
+            option_type=OptionType.CALL,
+        )
+        portfolio.add_position(
+            strike_price=105.0,
+            maturity_date=maturity1,
+            quantity=-1,
+            option_type=OptionType.CALL,
+        )
+        portfolio.add_position(
+            strike_price=95.0,
+            maturity_date=maturity2,
+            quantity=1,
+            option_type=OptionType.PUT,
+        )
+
+        fig = plot_greeks_consolidated(portfolio, top_n=5)
+
+        assert len(fig.axes) == 8
+        titles = {ax.get_title() for ax in fig.axes}
+        assert titles == {
+            "Top 5 Delta Contributors",
+            "Top 5 Gamma Contributors",
+            "Top 5 Vega Contributors",
+            "Top 5 Theta Contributors",
+            "Top 5 Position Values by Strike",
+            "Top 5 Position Values by Maturity",
+            "Greeks by Strike",
+            "Greeks by Maturity",
+        }
+
+        by_title = {ax.get_title(): ax for ax in fig.axes}
+        assert by_title["Top 5 Delta Contributors"].get_xlabel() == "Delta"
+        assert (
+            by_title["Top 5 Theta Contributors"].get_xlabel() == "Theta ($/day)"
+        )
+        assert by_title["Greeks by Strike"].get_xlabel() == "Strike Price"
+        assert by_title["Greeks by Maturity"].get_xlabel() == "Maturity Date"
+
+        plt.close(fig)
+
     def test_full_workflow(self) -> None:
         """Test full workflow with all chart types."""
         portfolio = OptionPortfolio(

--- a/tests/test_visualization/test_pnl_charts.py
+++ b/tests/test_visualization/test_pnl_charts.py
@@ -101,3 +101,54 @@ class TestPnLChartsMixin:
 
         assert fig is not None
         plt.close(fig)
+
+    def test_plot_pnl_distribution_figure_structure(self) -> None:
+        """Test annotation structure: axes, title, and every metric label.
+
+        Uses a put spread (no naked short calls, no long calls) so that
+        max loss and max profit are both bounded, exercising every
+        annotation branch: percentile levels, current spot, breakeven,
+        max loss, max profit, and expected value.
+        """
+        portfolio = OptionPortfolio(spot_price=100.0)
+        maturity = datetime.now(tz=UTC) + timedelta(days=30)
+
+        portfolio.add_position(
+            strike_price=105.0,
+            maturity_date=maturity,
+            quantity=1,
+            option_type=OptionType.PUT,
+        )
+        portfolio.add_position(
+            strike_price=95.0,
+            maturity_date=maturity,
+            quantity=-1,
+            option_type=OptionType.PUT,
+        )
+
+        charts = OptionCharts(portfolio)
+        fig = charts.plot_pnl_distribution_with_metrics(
+            num_points=200,
+            include_underlying=False,
+        )
+        ax = fig.axes[0]
+
+        assert len(fig.axes) == 1
+        assert ax.get_title() == (
+            "P&L Distribution with Key Metrics (Options Only)"
+        )
+        assert ax.get_xlabel() == "Spot Price at Maturity ($)"
+        assert ax.get_ylabel() == "Profit / Loss ($)"
+
+        annotation_texts = {t.get_text() for t in ax.texts}
+        assert annotation_texts == {
+            "5% @ $91",
+            "95% @ $110",
+            "Current Spot\n$100",
+            "BE $100.34",
+            "ML $-491",
+            "MP $509",
+            "EV $-8",
+        }
+
+        plt.close(fig)


### PR DESCRIPTION
## Summary
Three functions carried scoped pylint design-limit disables (R0912/R0913/R0914/R0915) left over from before `ips.yaml`'s pylint limits were tightened to the codebase's real ceiling. Each is now decomposed into cohesive, tested helpers, with the disable removed and behaviour verified byte-identical.

- `format_risk_reward_summary` (`deltadewa/analysis/summary.py`) — replaced a 14+ branch if/elif chain with a small dispatch-table pattern (`_resolve` + per-case row tables for capital/breakeven/max-loss/max-profit cases).
- `plot_pnl_distribution_with_metrics` (`deltadewa/visualization/pnl_charts.py`) — extracted the annotation logic (percentile lines, breakevens, max loss/profit, expected value) into named helper methods declared on `_VisualizationProtocol`.
- `plot_greeks_consolidated` (`deltadewa/visualization/convenience.py`) — extracted per-panel drawing into `_draw_greek_contributors_panel` / `_draw_value_by_dimension_panel` / `_draw_greeks_by_dimension_panel`, each called once per Greek/dimension via a `_GreekPanelStyle` parameter object.

Closes #152, closes #153, closes #154.

## Test plan
- [x] `poetry run pytest` — 1009 passed
- [x] `poetry run mypy deltadewa` — strict, clean
- [x] `poetry run ruff check .` — clean
- [x] `poetry run pylint deltadewa` — 10.00/10
- [x] `poetry run nbqa ruff monitor_dashboard.ipynb` / `hedge_design.ipynb` — clean
- [x] `grep -rn "R0914\|R0912\|R0915" deltadewa/visualization deltadewa/analysis/summary.py` — empty
- [x] Headless `nbconvert --execute` of both notebooks, diffed cell-by-cell against pre-refactor baseline (normalizing timestamps/UUIDs) — output-identical
- [x] New characterization/figure-structure tests added per function, cross-checked against pre-refactor code via `git stash`/worktree

🤖 Generated with [Claude Code](https://claude.com/claude-code)