### PR TITLE
build(lint): resolve ruff/pylint config conflicts and align tool pins

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -4107,4 +4107,4 @@ files = [
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.11,<4.0"
-content-hash = "b4b5ffe2ad6d126907f2a9c55f3daa78186b13e90d1c5e17a6d5aadada7eba62"
+content-hash = "6fb344c2866dc00cd5e0234746a35b639379e159f9093c47df9ab36103c0fe41"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -85,6 +85,8 @@ select = [
 ]
 ignore = [
 	"COM812", # conflicts with ruff formatter (formatter manages trailing commas)
+	"D203",   # incompatible with D211; codebase uses D211 (no blank line before class docstring)
+	"D213",   # incompatible with D212; codebase uses D212 (summary on first line)
 ]
 
 [tool.ruff.lint.per-file-ignores]
@@ -98,7 +100,7 @@ ignore = [
 
 [dependency-groups]
 dev = [
-	"ruff (>=0.5.3)",
+	"ruff (>=0.14.9)",
 	"pre-commit (>=4.0,<5.0)",
 	"debugpy (>=1.8.19,<2.0.0)",
 	"mypy>=1.10",
@@ -146,10 +148,6 @@ disable = [
 	"too-many-positional-arguments",
 	# C0302 large but cohesive widget/dashboard modules are acceptable
 	"too-many-lines",
-	"incorrect-blank-line-before-class",
-	# (D203) and no-blank-line-before-class (D211) are incompatible
-	"multi-line-summary-second-line,",
-	# (D212) and multi-line-summary-second-line (D213) are incompatible
 ]
 
 [tool.pylint.design]


### PR DESCRIPTION
- Ruff: ignore D203/D213 so the D203-vs-D211 and D212-vs-D213 pydocstyle conflicts stop warning; codebase already conforms to D211 + D212, so no code changes.
- Pylint: drop the two ruff rule names (incorrect-blank-line-before-class, multi-line-summary-second-line) from the disable list — they were unknown-option-value no-ops triggering W0012. Score stays 10.00/10.
- Align ruff pins: bump dev-group floor >=0.5.3 -> >=0.14.9 to match the pre-commit v0.14.9 pin and installed version; refresh poetry.lock hash.