### PR TITLE
fix(engine): preserve position identity, reprice on vol change, persi…

### DIFF
--- a/deltadewa/persistence.py
+++ b/deltadewa/persistence.py
@@ -157,6 +157,7 @@ class PortfolioSerializer:
                 "maturity_date": pos.option.maturity_date.isoformat(),
                 "quantity": pos.quantity,
                 "contract_size": pos.contract_size,
+                "exercise_style": pos.exercise_style.value,
                 "volatility": pos.option.volatility,
                 "custom_volatility": pos.custom_volatility,
                 "greeks": {
@@ -348,12 +349,18 @@ class PortfolioSerializer:
         self,
         filepath: str | Path,
         create_portfolio: bool = True,
+        default_exercise_style: ExerciseStyle = ExerciseStyle.AMERICAN,
     ) -> dict[str, Any]:
         """Import portfolio from JSON file.
 
         Args:
             filepath: path to JSON file
             create_portfolio: if True, creates and returns portfolio object
+            default_exercise_style: exercise style applied to positions whose
+            entry has no explicit ``exercise_style`` (e.g. files predating
+            exercise-style serialization).  Callers should pass the program's
+            IPS style (``ips_config.pricing.exercise_style``); defaults to
+            ``ExerciseStyle.AMERICAN`` to preserve legacy behaviour.
 
         Returns:
             dict with portfolio data (and 'portfolio' key if
@@ -381,6 +388,7 @@ class PortfolioSerializer:
             risk_free_rate=market_params["risk_free_rate"],
             dividend_yield=market_params["dividend_yield"],
             symbol=market_params.get("symbol", "UNKNOWN"),
+            default_exercise_style=default_exercise_style,
             contract_size=market_params["contract_size"],
         )
 
@@ -411,12 +419,23 @@ class PortfolioSerializer:
                 else None
             )
 
+            # Honor a serialized exercise_style; when absent (legacy files),
+            # add_position falls back to the portfolio's default style.
+            raw_style = pos_data.get("exercise_style")
+            exercise_style: ExerciseStyle | None = None
+            if raw_style is not None:
+                try:
+                    exercise_style = ExerciseStyle(str(raw_style).upper())
+                except ValueError:
+                    exercise_style = None
+
             imported_portfolio.add_position(
                 strike_price=strike,
                 maturity_date=maturity,
                 option_type=option_type,
                 quantity=quantity,
                 volatility=position_volatility,
+                exercise_style=exercise_style,
             )
 
             # Set entry tracking directly (not via add_position's kwargs)
@@ -438,11 +457,20 @@ class PortfolioSerializer:
             "metadata": data.get("metadata", {}),
         }
 
-    def import_from_yaml(self, filepath: str | Path) -> dict[str, Any]:
+    def import_from_yaml(
+        self,
+        filepath: str | Path,
+        default_exercise_style: ExerciseStyle = ExerciseStyle.AMERICAN,
+    ) -> dict[str, Any]:
         """Import portfolio from YAML configuration file.
 
         Args:
             filepath: path to YAML file
+            default_exercise_style: exercise style applied to positions whose
+            config has no explicit ``exercise_style``.  Callers should pass the
+            program's IPS style (``ips_config.pricing.exercise_style``);
+            defaults to ``ExerciseStyle.AMERICAN`` to preserve legacy
+            behaviour.
 
         Returns:
             dict with 'portfolio', 'market_params', and 'metadata' keys
@@ -471,6 +499,7 @@ class PortfolioSerializer:
             dividend_yield=market_params["dividend_yield"],
             valuation_date=dt.now(tz=datetime.UTC),
             symbol=market_params.get("symbol", "UNKNOWN"),
+            default_exercise_style=default_exercise_style,
             contract_size=market_params["contract_size"],
         )
 
@@ -533,11 +562,19 @@ class PortfolioSerializer:
             "metadata": {"source": "yaml", "filepath": str(filepath)},
         }
 
-    def import_portfolio(self, filepath: str | Path) -> dict[str, Any]:
+    def import_portfolio(
+        self,
+        filepath: str | Path,
+        default_exercise_style: ExerciseStyle = ExerciseStyle.AMERICAN,
+    ) -> dict[str, Any]:
         """Universal import function - auto-detects file format.
 
         Args:
             filepath: path to JSON or YAML file
+            default_exercise_style: exercise style applied to positions with no
+            explicit ``exercise_style``; forwarded to the format-specific
+            importer.  Callers should pass the IPS style
+            (``ips_config.pricing.exercise_style``).
 
         Returns:
             dict with 'portfolio', 'market_params', and 'metadata' keys
@@ -546,7 +583,14 @@ class PortfolioSerializer:
         file_format = self.detect_file_format(filepath)
 
         if file_format == "yaml":
-            return self.import_from_yaml(filepath)
+            return self.import_from_yaml(
+                filepath,
+                default_exercise_style=default_exercise_style,
+            )
         if file_format == "json":
-            return self.import_from_json(filepath, create_portfolio=True)
+            return self.import_from_json(
+                filepath,
+                create_portfolio=True,
+                default_exercise_style=default_exercise_style,
+            )
         raise ValueError(f"Unsupported file format: {filepath}")

--- a/deltadewa/portfolio/core.py
+++ b/deltadewa/portfolio/core.py
@@ -159,7 +159,9 @@ class OptionPortfolioBase:
         self.volatility = volatility
         for pos in self.positions:
             if not pos.custom_volatility:
-                pos.option.volatility = volatility
+                # Route through update_volatility() so the QuantLib quote and
+                # the greek cache are updated, not just the Python attribute.
+                pos.option.update_volatility(volatility)
 
     def get_symbol(self) -> str:
         """Get the symbol of the portfolio."""
@@ -491,6 +493,11 @@ class OptionPortfolioBase:
                         # Preserve custom volatility flag
                         custom_volatility=pos.custom_volatility,
                         exercise_style=pos.exercise_style,
+                        # Preserve cost basis and identity across the rebuild
+                        entry_spot=pos.entry_spot,
+                        entry_date=pos.entry_date,
+                        entry_premium=pos.entry_premium,
+                        position_id=pos.position_id,
                     ),
                 )
             self.positions = new_positions

--- a/tests/test_persistence.py
+++ b/tests/test_persistence.py
@@ -11,7 +11,7 @@ import pytest
 import yaml
 
 from deltadewa import OptionPortfolio
-from deltadewa.constants import OptionType
+from deltadewa.constants import ExerciseStyle, OptionType
 from deltadewa.persistence import (
     YAML_AVAILABLE,
     PortfolioSerializer,
@@ -339,6 +339,74 @@ class TestJsonRoundtrip:
         assert imported_portfolio.positions[0].entry_spot is None
         assert imported_portfolio.positions[0].entry_date is None
 
+    def test_json_roundtrip_preserves_exercise_style(self, tmp_path) -> None:
+        """Regression (C2): a European book must reload European via JSON.
+
+        The old export never wrote exercise_style and the import never read
+        it, so a European (SPX) leg silently re-marked to American on reload.
+        """
+        portfolio = OptionPortfolio(spot_price=100.0, volatility=0.2)
+        portfolio.add_position(
+            strike_price=90.0,
+            maturity_date=datetime.now(tz=UTC) + timedelta(days=365),
+            quantity=1,
+            option_type=OptionType.PUT,
+            exercise_style=ExerciseStyle.EUROPEAN,
+        )
+
+        serializer = PortfolioSerializer(tmp_path)
+        changelog = PortfolioLogger()
+        output_path = serializer.export_to_json(portfolio, changelog, "eu.json")
+        imported = serializer.import_from_json(output_path)["portfolio"]
+
+        pos = imported.positions[0]
+        assert pos.exercise_style == ExerciseStyle.EUROPEAN
+        assert pos.option.exercise_style == ExerciseStyle.EUROPEAN
+
+    def test_json_import_defaults_missing_exercise_style_from_arg(
+        self,
+        tmp_path,
+    ) -> None:
+        """Regression (C2): legacy legs honor the import default exercise style.
+
+        A file lacking per-position exercise_style must adopt the caller's
+        default (the program's IPS style) instead of the hardcoded American.
+        """
+        legacy_data = {
+            "market_parameters": {
+                "spot_price": 100.0,
+                "volatility": 0.2,
+                "risk_free_rate": 0.05,
+                "dividend_yield": 0.0,
+                "underlying_quantity": 0.0,
+                "symbol": "SPX",
+                "contract_size": 100,
+            },
+            "positions": [
+                {
+                    "option_type": "PUT",
+                    "strike_price": 90.0,
+                    "maturity_date": "2030-01-01T00:00:00+00:00",
+                    "quantity": 1,
+                    "contract_size": 100,
+                    "volatility": 0.2,
+                    "custom_volatility": False,
+                },
+            ],
+            "risk_metrics": {},
+        }
+        legacy_path = tmp_path / "legacy_spx.json"
+        legacy_path.write_text(json.dumps(legacy_data))
+
+        serializer = PortfolioSerializer(tmp_path)
+        result = serializer.import_from_json(
+            legacy_path,
+            default_exercise_style=ExerciseStyle.EUROPEAN,
+        )
+        pos = result["portfolio"].positions[0]
+        assert pos.exercise_style == ExerciseStyle.EUROPEAN
+        assert pos.option.exercise_style == ExerciseStyle.EUROPEAN
+
     def test_import_from_json_without_portfolio_creation(
         self,
         tmp_path,
@@ -565,6 +633,32 @@ class TestYamlRoundtrip:
                 imported_pos.option.option_type == orig_pos.option.option_type
             )
             assert imported_pos.quantity == orig_pos.quantity
+
+    def test_yaml_roundtrip_preserves_exercise_style(self, tmp_path) -> None:
+        """Regression (C2): European legs must reload European via YAML.
+
+        YAML import already parsed exercise_style, but the shared export
+        builder never wrote it, so the round-trip still lost the style.
+        """
+        portfolio = OptionPortfolio(spot_price=100.0, volatility=0.2)
+        portfolio.add_position(
+            strike_price=90.0,
+            maturity_date=datetime.now(tz=UTC) + timedelta(days=365),
+            quantity=1,
+            option_type=OptionType.PUT,
+            exercise_style=ExerciseStyle.EUROPEAN,
+        )
+
+        serializer = PortfolioSerializer(tmp_path)
+        changelog = PortfolioLogger()
+        output_path = serializer.export_to_yaml(portfolio, changelog, "eu.yaml")
+
+        assert output_path is not None
+        imported = serializer.import_from_yaml(output_path)["portfolio"]
+
+        pos = imported.positions[0]
+        assert pos.exercise_style == ExerciseStyle.EUROPEAN
+        assert pos.option.exercise_style == ExerciseStyle.EUROPEAN
 
     def test_yaml_roundtrip_with_maturity_days(self, tmp_path) -> None:
         """Test YAML import with maturity_days instead of maturity_date."""

--- a/tests/test_portfolio/test_core.py
+++ b/tests/test_portfolio/test_core.py
@@ -3,6 +3,8 @@
 import unittest
 from datetime import UTC, datetime, timedelta
 
+import pytest
+
 from deltadewa.constants import ExerciseStyle, OptionType
 from deltadewa.portfolio.core import OptionPortfolio, OptionPortfolioBase
 
@@ -422,6 +424,72 @@ class TestOptionPortfolioBase:
 
         assert portfolio.volatility == 0.3
         assert portfolio.positions[0].option.volatility == 0.3
+
+    def test_set_volatility_reprices_leg(self) -> None:
+        """Regression (M4): set_volatility must reprice, not just set the attr.
+
+        The old implementation assigned ``pos.option.volatility`` directly,
+        leaving the QuantLib quote and the greek cache stale, so ``price()``
+        returned the value at the *previous* vol.
+        """
+        maturity = datetime.now(tz=UTC) + timedelta(days=30)
+        portfolio = OptionPortfolioBase(spot_price=100.0, volatility=0.2)
+        portfolio.add_position(
+            strike_price=100.0,
+            maturity_date=maturity,
+            quantity=1,
+            option_type=OptionType.CALL,
+        )
+        price_before = portfolio.positions[0].option.price()
+
+        # Reference leg built directly at the higher vol for comparison.
+        reference = OptionPortfolioBase(spot_price=100.0, volatility=0.5)
+        reference.add_position(
+            strike_price=100.0,
+            maturity_date=maturity,
+            quantity=1,
+            option_type=OptionType.CALL,
+        )
+        expected_price = reference.positions[0].option.price()
+
+        portfolio.set_volatility(0.5)
+        price_after = portfolio.positions[0].option.price()
+
+        # An ATM call is worth more at higher vol; the old code left it flat.
+        assert price_after > price_before
+        assert price_after == pytest.approx(expected_price)
+
+    def test_update_market_conditions_rate_change_preserves_identity(
+        self,
+    ) -> None:
+        """Regression (C3): the rate/dividend rebuild must keep entry + id.
+
+        Changing the risk-free rate or dividend yield recreates every
+        OptionPosition; the old rebuild dropped entry_spot/date/premium and
+        minted a fresh position_id, silently losing cost basis and identity.
+        """
+        portfolio = OptionPortfolioBase(spot_price=100.0, volatility=0.2)
+        entry_date = datetime(2026, 1, 2, tzinfo=UTC)
+        portfolio.add_position(
+            strike_price=100.0,
+            maturity_date=datetime.now(tz=UTC) + timedelta(days=30),
+            quantity=1,
+            option_type=OptionType.CALL,
+            entry_spot=98.0,
+            entry_date=entry_date,
+        )
+        pos = portfolio.positions[0]
+        pos.entry_premium = 4.25
+        original_id = pos.position_id
+
+        # Rate change triggers the position-rebuild branch.
+        portfolio.update_market_conditions(risk_free_rate=0.06)
+
+        rebuilt = portfolio.positions[0]
+        assert rebuilt.entry_spot == 98.0
+        assert rebuilt.entry_date == entry_date
+        assert rebuilt.entry_premium == pytest.approx(4.25)
+        assert rebuilt.position_id == original_id
 
     def test_get_symbol(self) -> None:
         """Test get_symbol method."""


### PR DESCRIPTION
…st exercise style

C3: update_market_conditions() rate/dividend rebuild now preserves entry_spot/entry_date/entry_premium and position_id instead of resetting cost basis to None and minting a fresh UUID.

M4: set_volatility() routes non-custom legs through OptionValuation.update_volatility() so the QuantLib quote and greek cache are updated, not just the Python attribute (which left prices stale).

C2 (logic half): serialize exercise_style in the shared JSON/YAML export builder, honor it on JSON import (mirroring YAML), and add a default_exercise_style parameter to the importers so positions lacking an explicit style adopt the program's IPS style instead of the hardcoded American default. Editor-dropdown default and widget import-apply wiring are deferred to M2.3.

Adds 5 regression tests (each fails on the pre-fix code).