### PR TITLE
test(m1.1): custom-vol guard + persistence mark assertions

### DIFF
--- a/tests/test_persistence.py
+++ b/tests/test_persistence.py
@@ -353,6 +353,9 @@ class TestJsonRoundtrip:
             option_type=OptionType.PUT,
             exercise_style=ExerciseStyle.EUROPEAN,
         )
+        # Capture the European mark; an American re-mark would move the price
+        # by the early-exercise premium, so this pins the style end-to-end.
+        original_price = portfolio.positions[0].option.price()
 
         serializer = PortfolioSerializer(tmp_path)
         changelog = PortfolioLogger()
@@ -362,6 +365,7 @@ class TestJsonRoundtrip:
         pos = imported.positions[0]
         assert pos.exercise_style == ExerciseStyle.EUROPEAN
         assert pos.option.exercise_style == ExerciseStyle.EUROPEAN
+        assert pos.option.price() == pytest.approx(original_price)
 
     def test_json_import_defaults_missing_exercise_style_from_arg(
         self,
@@ -648,6 +652,9 @@ class TestYamlRoundtrip:
             option_type=OptionType.PUT,
             exercise_style=ExerciseStyle.EUROPEAN,
         )
+        # Capture the European mark; an American re-mark would move the price
+        # by the early-exercise premium, so this pins the style end-to-end.
+        original_price = portfolio.positions[0].option.price()
 
         serializer = PortfolioSerializer(tmp_path)
         changelog = PortfolioLogger()
@@ -659,6 +666,7 @@ class TestYamlRoundtrip:
         pos = imported.positions[0]
         assert pos.exercise_style == ExerciseStyle.EUROPEAN
         assert pos.option.exercise_style == ExerciseStyle.EUROPEAN
+        assert pos.option.price() == pytest.approx(original_price)
 
     def test_yaml_roundtrip_with_maturity_days(self, tmp_path) -> None:
         """Test YAML import with maturity_days instead of maturity_date."""

--- a/tests/test_portfolio/test_core.py
+++ b/tests/test_portfolio/test_core.py
@@ -459,6 +459,31 @@ class TestOptionPortfolioBase:
         assert price_after > price_before
         assert price_after == pytest.approx(expected_price)
 
+    def test_set_volatility_skips_custom_volatility_leg(self) -> None:
+        """Regression (M4): a custom-vol leg must be left untouched.
+
+        ``set_volatility`` only repositions legs whose vol tracks the
+        portfolio; a leg with an explicit ``custom_volatility`` must keep both
+        its vol quote and its price when the portfolio vol moves.
+        """
+        maturity = datetime.now(tz=UTC) + timedelta(days=30)
+        portfolio = OptionPortfolioBase(spot_price=100.0, volatility=0.2)
+        portfolio.add_position(
+            strike_price=100.0,
+            maturity_date=maturity,
+            quantity=1,
+            option_type=OptionType.CALL,
+            volatility=0.3,
+        )
+        custom_leg = portfolio.positions[0]
+        assert custom_leg.custom_volatility is True
+        price_before = custom_leg.option.price()
+
+        portfolio.set_volatility(0.5)
+
+        assert custom_leg.option.volatility == 0.3
+        assert custom_leg.option.price() == pytest.approx(price_before)
+
     def test_update_market_conditions_rate_change_preserves_identity(
         self,
     ) -> None:


### PR DESCRIPTION
Follow-up to #189 (M1.1 — stop data loss and silent mispricing).

While reviewing M1.1, two test-only improvements were added *after* #189 had
already merged, so they never reached `main`. This PR lands just those 33
lines. **No source changes** — the C3/M4/C2 fixes are already in `main`.

## What's added

**1. `test_set_volatility_skips_custom_volatility_leg`** (`test_core.py`, +25)
Pins the `if not pos.custom_volatility` guard in `set_volatility()`: a leg with
an explicit custom volatility must keep both its vol quote and its price when
the portfolio vol moves. Mutation-verified — with the guard removed the test
fails (`0.5 == 0.3`). Complements the M4 `test_set_volatility_reprices_leg`
(which proves the *non*-custom leg does reprice).

**2. Mark assertions on the exercise-style round-trips** (`test_persistence.py`, +8)
The JSON and YAML `exercise_style` round-trip tests now also assert
`option.price() == pytest.approx(original)` after import. This proves the style
still *drives pricing* end-to-end, not merely that the enum attribute survives —
a silent European→American re-mark moves the mark ~6.9% at the test params, far
outside `approx` tolerance.

## Verification
- `ruff check .` clean · `pylint deltadewa` 10.00/10 · `mypy deltadewa` strict clean
- `pytest` — 1015 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)