### PR TITLE
build: single-source version from package metadata, bump to 0.3.0

### DIFF
--- a/deltadewa/__init__.py
+++ b/deltadewa/__init__.py
@@ -1,6 +1,11 @@
 """deltadewa — SPX tail-risk hedging system, QuantLib-priced."""
 
-__version__ = "0.1.0"
+from importlib.metadata import PackageNotFoundError, version
+
+try:
+    __version__ = version("deltadewa")
+except PackageNotFoundError:
+    __version__ = "0.0.0+unknown"
 
 from .batch_pricer import BatchPricer
 from .constants import (

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "deltadewa"
-version = "0.2.0"
+version = "0.3.0"
 description = "Options dashboard using QuantLib"
 readme = "README.md"
 authors = [{ name = "qwertytam" }]


### PR DESCRIPTION
Single-source version from installed package metadata to eliminate divergence between `__version__` and `pyproject.toml`.

Bumps version to 0.3.0 (correctness release).

- Replaces hardcoded `__version__ = "0.1.0"` with `importlib.metadata.version("deltadewa")`
- Updates `pyproject.toml` version to 0.3.0
- Gate: pytest ✓, mypy strict ✓, ruff ✓, pylint 10.00/10 ✓

Will be squashed and merged to main, then tagged as v0.3.0-correctness.