### PR TITLE
M1.6 — skew-aware crash shock

### DIFF
--- a/config/ips.yaml
+++ b/config/ips.yaml
@@ -26,6 +26,9 @@ convexity:
   target_min_pct: 15.0
   target_max_pct: 25.0
   crash_vol_shock: 0.15         # flat additive vol bump at the crash spot (M1.2)
+  skew_steepening: 0.10         # extra vol at the deep-OTM tail over ATM, linear
+                                # in log-moneyness (M1.6; methodology §2). 0.0
+                                # keeps the flat bump.
   crash_floor_reported: true    # surface the intrinsic-floor column
 
 drawdown:

--- a/deltadewa/analysis/crash_payoff.py
+++ b/deltadewa/analysis/crash_payoff.py
@@ -29,7 +29,10 @@ from deltadewa.analysis.crash_repricing import (
     crash_hedge_value,
     crash_intrinsic_floor,
 )
-from deltadewa.ips_config import _DEFAULT_CRASH_VOL_SHOCK
+from deltadewa.ips_config import (
+    _DEFAULT_CRASH_VOL_SHOCK,
+    _DEFAULT_SKEW_STEEPENING,
+)
 
 if TYPE_CHECKING:
     from collections.abc import Sequence
@@ -193,6 +196,7 @@ def crash_payoff_ratio(
     *,
     crash_pct: float,
     vol_shock: float,
+    skew_steepening: float = 0.0,
     premium: float | None = None,
 ) -> float:
     """Repriced hedge payoff at a crash shock, as a multiple of premium paid.
@@ -208,6 +212,10 @@ def crash_payoff_ratio(
             single-sourced from ``IpsConvexity.crash_vol_shock`` so it can
             never silently diverge from the crash scenario; pass ``0.0``
             explicitly for a spot-only crash when no IPS shock applies.
+        skew_steepening: Optional deep-OTM skew steepening added on top of
+            ``vol_shock`` at the tail (M1.6), single-sourced from
+            ``IpsConvexity.skew_steepening``. ``0.0`` (the default) keeps the
+            flat bump.
         premium: Premium paid for the hedge in dollars.  Defaults to
             ``_premium_with_basis(portfolio)`` (entry cost when available,
             current mark otherwise) when not supplied.
@@ -225,6 +233,7 @@ def crash_payoff_ratio(
         portfolio,
         crash_move=crash_pct / 100.0,
         vol_shock=vol_shock,
+        skew_steepening=skew_steepening,
         positions=_long_puts(portfolio),
     )
     return repriced / premium
@@ -235,6 +244,7 @@ def _reprice_shock_grid(
     positions: list[OptionPosition],
     shocks: set[float],
     vol_shock: float,
+    skew_steepening: float,
 ) -> tuple[dict[float, float], dict[float, float]]:
     """Reprice each shock exactly once: ``(repriced, intrinsic_floor)`` maps.
 
@@ -243,6 +253,8 @@ def _reprice_shock_grid(
         positions: Legs to price (typically the long puts).
         shocks: Unique signed shock percents to price.
         vol_shock: Flat additive crash vol bump as a decimal.
+        skew_steepening: Deep-OTM skew steepening added at the tail (M1.6);
+            ``0.0`` keeps the flat bump.
 
     Returns:
         Two dicts keyed by shock percent: the repriced hedge value and the
@@ -257,6 +269,7 @@ def _reprice_shock_grid(
             portfolio,
             crash_move=move,
             vol_shock=vol_shock,
+            skew_steepening=skew_steepening,
             positions=positions,
         )
         floor[shock] = crash_intrinsic_floor(
@@ -275,6 +288,7 @@ def _build_scenario_rows(
     floor: dict[float, float],
     premium_paid: float,
     vol_shock: float,
+    skew_steepening: float,
     ips_convexity: IpsConvexity | None,
 ) -> list[CrashScenarioRow]:
     """Assemble scenario rows from the pre-priced grid, sorted mild to severe.
@@ -286,6 +300,8 @@ def _build_scenario_rows(
         floor: Intrinsic floor keyed by shock percent.
         premium_paid: Premium denominator for the payoff ratio (dollars).
         vol_shock: Flat additive crash vol bump as a decimal.
+        skew_steepening: Deep-OTM skew steepening added at the tail (M1.6);
+            ``0.0`` keeps the flat bump.
         ips_convexity: IPS convexity target, or ``None``.
 
     Returns:
@@ -300,6 +316,7 @@ def _build_scenario_rows(
         convexity_pct = analyzer.calculate_crash_convexity_pct(
             crash_scenario_pct=shock_pct,
             crash_vol_shock=vol_shock,
+            skew_steepening=skew_steepening,
         )
         meets_target = (
             ips_convexity.target_min_pct
@@ -325,6 +342,7 @@ def compute_crash_convexity(
     portfolio: OptionPortfolio,
     *,
     crash_vol_shock: float,
+    skew_steepening: float = 0.0,
     shock_range: tuple[float, float] = (-40.0, 10.0),
     n_points: int = 51,
     ips_convexity: IpsConvexity | None = None,
@@ -347,6 +365,10 @@ def compute_crash_convexity(
             +1000 bps).  Decoupled from policy: explicit parameter forces
             every caller to state the shock it prices with.  No path reprices
             spot-only by omission.
+        skew_steepening: Optional deep-OTM skew steepening added on top of
+            ``crash_vol_shock`` at the tail (M1.6), single-sourced from
+            ``IpsConvexity.skew_steepening``. ``0.0`` (the default) keeps the
+            flat bump.
         shock_range: (min_shock_pct, max_shock_pct) bounding the grid.
         n_points: Number of evenly-spaced points in the fine grid.
         ips_convexity: IPS convexity target (policy, not pricing).  When
@@ -398,6 +420,7 @@ def compute_crash_convexity(
         long_puts,
         all_shocks,
         vol_shock,
+        skew_steepening,
     )
 
     # Curve — fine grid only, sorted ascending (severe left to mild right).
@@ -413,6 +436,7 @@ def compute_crash_convexity(
         floor=floor,
         premium_paid=premium_paid,
         vol_shock=vol_shock,
+        skew_steepening=skew_steepening,
         ips_convexity=ips_convexity,
     )
 
@@ -444,9 +468,9 @@ def crash_scenario_table(
         shocks: Signed shock percents (e.g. [-10.0, -25.0]).
             ``ips_convexity.crash_scenario_pct`` is added automatically
             when not already present (if ips_convexity is supplied).
-        ips_convexity: IPS convexity config (provides crash_vol_shock for
-            pricing and target band comparison). When None, uses default
-            crash_vol_shock (0.15).
+        ips_convexity: IPS convexity config (provides crash_vol_shock and
+            skew_steepening for pricing, and the target band comparison). When
+            None, uses default crash_vol_shock (0.15) and skew_steepening (0.0).
 
     Returns:
         One ``CrashScenarioRow`` per shock, sorted mild to severe.
@@ -457,9 +481,15 @@ def crash_scenario_table(
         if ips_convexity is not None
         else _DEFAULT_CRASH_VOL_SHOCK
     )
+    skew_steepening = (
+        ips_convexity.skew_steepening
+        if ips_convexity is not None
+        else _DEFAULT_SKEW_STEEPENING
+    )
     return compute_crash_convexity(
         portfolio,
         crash_vol_shock=vol_shock,
+        skew_steepening=skew_steepening,
         ips_convexity=ips_convexity,
         scenario_shocks=shocks,
     ).scenario_rows

--- a/deltadewa/analysis/crash_repricing.py
+++ b/deltadewa/analysis/crash_repricing.py
@@ -24,6 +24,7 @@ analytic Black-Scholes engine); no new pricer is introduced.
 
 from __future__ import annotations
 
+import math
 from typing import TYPE_CHECKING
 
 from deltadewa.constants import OptionType
@@ -73,11 +74,102 @@ def _reprice_leg(
     return option.price() * position.quantity * position.contract_size
 
 
+def _tail_log_moneyness(
+    legs: Sequence[OptionPosition],
+    spot: float,
+) -> float:
+    """Log-moneyness ``ln(S / K_tail)`` of the deepest OTM put among *legs*.
+
+    ``K_tail`` is the lowest strike held as an out-of-the-money put
+    (``option_type == PUT`` and ``strike < spot``) — the tail anchor where the
+    skew weight reaches 1. Returns ``0.0`` when no OTM put is present, which
+    disables the steepening (there is no put wing to anchor).
+
+    Args:
+        legs: Option legs being repriced.
+        spot: Today's underlying spot the moneyness is measured against.
+
+    Returns:
+        ``ln(spot / K_tail)`` (positive), or ``0.0`` when there is no OTM put.
+
+    """
+    otm_put_strikes = [
+        position.option.strike_price
+        for position in legs
+        if position.option.option_type == OptionType.PUT
+        and position.option.strike_price < spot
+    ]
+    if not otm_put_strikes:
+        return 0.0
+    return math.log(spot / min(otm_put_strikes))
+
+
+def _skew_weight(
+    position: OptionPosition,
+    spot: float,
+    tail_log_moneyness: float,
+) -> float:
+    """Log-moneyness interpolation weight ``w`` in ``[0, 1]`` for one leg.
+
+    ``0`` at ATM and for calls / ITM puts (no wing steepening), ``1`` at the
+    deepest OTM put (the tail anchor), linear in ``ln(S / K)`` between. The
+    leg's extra crash vol is ``skew_steepening * w``.
+
+    Args:
+        position: Option leg to weight.
+        spot: Today's underlying spot the moneyness is measured against.
+        tail_log_moneyness: ``ln(S / K_tail)`` from :func:`_tail_log_moneyness`.
+
+    Returns:
+        The interpolation weight in ``[0, 1]``.
+
+    """
+    if tail_log_moneyness <= 0.0:
+        return 0.0
+    if position.option.option_type != OptionType.PUT:
+        return 0.0
+    strike = position.option.strike_price
+    if strike >= spot:
+        return 0.0
+    return min(1.0, math.log(spot / strike) / tail_log_moneyness)
+
+
+def _leg_crash_vol(
+    position: OptionPosition,
+    vol_shock: float,
+    skew_steepening: float,
+    spot: float,
+    tail_log_moneyness: float,
+) -> float:
+    """Shocked crash vol for one leg: flat bump plus deep-OTM steepening.
+
+    When ``skew_steepening`` is ``0.0`` this returns exactly
+    ``position.option.volatility + vol_shock`` — the original flat-bump
+    expression — so the disabled knob reproduces every prior value bit-for-bit.
+
+    Args:
+        position: Option leg to shock.
+        vol_shock: Flat additive vol bump applied to every leg.
+        skew_steepening: Extra vol added at the deep-OTM tail (``0.0`` = off).
+        spot: Today's underlying spot the moneyness is measured against.
+        tail_log_moneyness: ``ln(S / K_tail)`` from :func:`_tail_log_moneyness`.
+
+    Returns:
+        The leg's shocked volatility as a decimal.
+
+    """
+    if skew_steepening == 0.0:
+        return position.option.volatility + vol_shock
+    weight = _skew_weight(position, spot, tail_log_moneyness)
+    return position.option.volatility + vol_shock + skew_steepening * weight
+
+
 def crash_hedge_value(
     portfolio: OptionPortfolio,
     *,
     crash_move: float,
     vol_shock: float,
+    skew_steepening: float = 0.0,
     positions: Sequence[OptionPosition] | None = None,
 ) -> float:
     """Hedge-only value of the option legs repriced at the crash state (§2-3).
@@ -91,6 +183,10 @@ def crash_hedge_value(
             spot is ``portfolio.spot_price * (1 + crash_move)``.
         vol_shock: Flat additive vol bump as a decimal (e.g. ``+0.15``) applied
             to every leg's own today-vol.
+        skew_steepening: Optional extra vol added at the deep-OTM tail on top of
+            ``vol_shock``, interpolated linearly in log-moneyness from ``0`` at
+            ATM to the full value at the deepest OTM put (M1.6). ``0.0`` (the
+            default) keeps the flat bump and reproduces prior values exactly.
         positions: Legs to price. Defaults to every position in the portfolio;
             pass a subset (e.g. the long puts) to value part of the book.
 
@@ -100,13 +196,24 @@ def crash_hedge_value(
     """
     legs = portfolio.positions if positions is None else positions
     crash_spot = portfolio.spot_price * (1.0 + crash_move)
+    tail_log_moneyness = (
+        _tail_log_moneyness(legs, portfolio.spot_price)
+        if skew_steepening != 0.0
+        else 0.0
+    )
     return float(
         sum(
             _reprice_leg(
                 position,
                 portfolio,
                 crash_spot,
-                position.option.volatility + vol_shock,
+                _leg_crash_vol(
+                    position,
+                    vol_shock,
+                    skew_steepening,
+                    portfolio.spot_price,
+                    tail_log_moneyness,
+                ),
             )
             for position in legs
         ),
@@ -144,6 +251,7 @@ def crash_convexity_pct(
     *,
     crash_move: float,
     vol_shock: float,
+    skew_steepening: float = 0.0,
 ) -> float:
     """Crash convexity: hedge-only value change as % of the protected book (§1).
 
@@ -156,6 +264,10 @@ def crash_convexity_pct(
         portfolio: Portfolio to evaluate.
         crash_move: Signed crash move as a decimal (e.g. ``-0.25``).
         vol_shock: Flat additive vol bump as a decimal (e.g. ``+0.15``).
+        skew_steepening: Optional deep-OTM skew steepening applied to the crash
+            leg only (M1.6). ``0.0`` (the default) keeps the flat bump. The
+            today-value ``V_today`` is always skew-free — steepening is a
+            crash-state effect.
 
     Returns:
         Crash convexity as a percentage of the protected book. ``0.0`` when the
@@ -170,6 +282,7 @@ def crash_convexity_pct(
         portfolio,
         crash_move=crash_move,
         vol_shock=vol_shock,
+        skew_steepening=skew_steepening,
     )
     return (v_crash - v_today) / book * 100.0
 

--- a/deltadewa/analysis/health.py
+++ b/deltadewa/analysis/health.py
@@ -197,6 +197,7 @@ class HealthMixin:
         self,
         crash_scenario_pct: float,
         crash_vol_shock: float,
+        skew_steepening: float = 0.0,
     ) -> float:
         """Calculate crash convexity, hedge-only and repriced (§1-3).
 
@@ -220,6 +221,12 @@ class HealthMixin:
                 caller (the gauge, the scenario table, and the roll trigger) so
                 no site can silently reprice at a different vol. Pass ``0.0``
                 explicitly for a spot-only crash when no IPS shock applies.
+            skew_steepening: Optional extra vol added at the deep-OTM tail on
+                top of ``crash_vol_shock``, interpolated linearly in
+                log-moneyness from ``0`` at ATM to the full value at the deepest
+                OTM put (M1.6). Single-sourced from
+                ``IpsConvexity.skew_steepening``; ``0.0`` (the default) keeps
+                the flat bump.
 
         Returns:
             Hedge-only crash convexity as a percentage of the protected book
@@ -231,6 +238,7 @@ class HealthMixin:
             self.portfolio,
             crash_move=crash_scenario_pct / 100.0,
             vol_shock=crash_vol_shock,
+            skew_steepening=skew_steepening,
         )
 
     def calculate_vega_sufficiency_pct(
@@ -517,6 +525,7 @@ class HealthMixin:
             crash_convexity_value = self.calculate_crash_convexity_pct(
                 crash.crash_scenario_pct,
                 crash.crash_vol_shock,
+                crash.skew_steepening,
             )
             hedge_success_pct = self.calculate_hedge_success_pct(
                 cumulative_carry_paid,

--- a/deltadewa/analysis/roll_status.py
+++ b/deltadewa/analysis/roll_status.py
@@ -223,12 +223,14 @@ def evaluate_roll_status(
     roll_window_days = triggers.roll_time_months * const.CALENDAR_DAYS_PER_MONTH
 
     analyzer = PortfolioAnalyzer(portfolio)
-    # Source the crash vol shock from the IPS so the roll trigger's convexity
-    # matches the health gauge / scenario table exactly; passing spot-only
-    # (vol_shock=0) understated convexity and biased the roll toward firing.
+    # Source the crash vol shock AND skew steepening from the IPS so the roll
+    # trigger's convexity matches the health gauge / scenario table exactly;
+    # passing spot-only (vol_shock=0) understated convexity and biased the roll
+    # toward firing.
     crash_convexity_pct = analyzer.calculate_crash_convexity_pct(
         crash_scenario_pct=convexity.crash_scenario_pct,
         crash_vol_shock=convexity.crash_vol_shock,
+        skew_steepening=convexity.skew_steepening,
     )
 
     # Measure DTE against the portfolio's (what-if) valuation date, not the

--- a/deltadewa/dashboard/crash_payoff_display.py
+++ b/deltadewa/dashboard/crash_payoff_display.py
@@ -187,9 +187,15 @@ class CrashPayoffDisplay:
             if self._ips_convexity is not None
             else 0.15
         )
+        skew_steepening = (
+            self._ips_convexity.skew_steepening
+            if self._ips_convexity is not None
+            else 0.0
+        )
         result = compute_crash_convexity(
             self._portfolio,
             crash_vol_shock=crash_vol_shock,
+            skew_steepening=skew_steepening,
             ips_convexity=self._ips_convexity,
             scenario_shocks=self._shocks,
         )

--- a/deltadewa/ips_config.py
+++ b/deltadewa/ips_config.py
@@ -18,9 +18,10 @@ from deltadewa.constants import ExerciseStyle
 # Defaults for the crash-repricing knobs that live alongside
 # ``crash_scenario_pct`` in the ``convexity`` section. The crash *move* itself
 # is single-sourced from ``crash_scenario_pct`` (never duplicated here); these
-# two knobs are the flat vol-bump magnitude and the intrinsic-floor toggle used
-# by the M1.2 crash-repricing metric.
+# knobs are the flat vol-bump magnitude, the deep-OTM skew steepening (M1.6),
+# and the intrinsic-floor toggle used by the M1.2 crash-repricing metric.
 _DEFAULT_CRASH_VOL_SHOCK: Final[float] = 0.15
+_DEFAULT_SKEW_STEEPENING: Final[float] = 0.0
 _DEFAULT_CRASH_FLOOR_REPORTED: Final[bool] = True
 
 # Default for the delta-drift target that lives alongside the delta_drift
@@ -125,17 +126,19 @@ class IpsConvexity:
     """Target convexity (hedge payoff) range under a crash scenario.
 
     ``crash_scenario_pct`` is the single source of truth for the crash *move*
-    (a signed percent, e.g. ``-25.0``) across every panel. ``crash_vol_shock``
-    and ``crash_floor_reported`` are the two crash-repricing knobs co-located
-    here (see ``docs/repricing-methodology.md`` §5): the flat additive
-    volatility bump applied at the crash spot, and whether the intrinsic-floor
-    column is surfaced.
+    (a signed percent, e.g. ``-25.0``) across every panel. ``crash_vol_shock``,
+    ``skew_steepening`` and ``crash_floor_reported`` are the crash-repricing
+    knobs co-located here (see ``docs/repricing-methodology.md`` §5): the flat
+    additive volatility bump applied at the crash spot, an optional deep-OTM
+    skew steepening added on top of that bump at the tail (M1.6; ``0.0`` keeps
+    the flat bump), and whether the intrinsic-floor column is surfaced.
     """
 
     crash_scenario_pct: float
     target_min_pct: float
     target_max_pct: float
     crash_vol_shock: float = _DEFAULT_CRASH_VOL_SHOCK
+    skew_steepening: float = _DEFAULT_SKEW_STEEPENING
     crash_floor_reported: bool = _DEFAULT_CRASH_FLOOR_REPORTED
 
 
@@ -315,6 +318,11 @@ def _parse_convexity(config: dict[str, Any]) -> IpsConvexity:
         _DEFAULT_CRASH_VOL_SHOCK,
     )
     _require_non_negative(crash_vol_shock, "convexity.crash_vol_shock")
+    skew_steepening = section.get(
+        "skew_steepening",
+        _DEFAULT_SKEW_STEEPENING,
+    )
+    _require_non_negative(skew_steepening, "convexity.skew_steepening")
     crash_floor_reported = bool(
         section.get("crash_floor_reported", _DEFAULT_CRASH_FLOOR_REPORTED),
     )
@@ -324,6 +332,7 @@ def _parse_convexity(config: dict[str, Any]) -> IpsConvexity:
         target_min_pct=target_min_pct,
         target_max_pct=target_max_pct,
         crash_vol_shock=crash_vol_shock,
+        skew_steepening=skew_steepening,
         crash_floor_reported=crash_floor_reported,
     )
 

--- a/deltadewa/widgets/summary.py
+++ b/deltadewa/widgets/summary.py
@@ -52,6 +52,7 @@ class NetHedgeSummary:
         portfolio: "OptionPortfolio",
         *,
         crash_vol_shock: float = 0.0,
+        skew_steepening: float = 0.0,
     ) -> None:
         """Initialize net hedge summary widget.
 
@@ -61,10 +62,16 @@ class NetHedgeSummary:
                 single-sourced from ``IpsConvexity.crash_vol_shock`` (pass
                 ``ctx.ips_config.convexity.crash_vol_shock``). Used to reprice
                 the hedge-only crash-convexity ladder. Defaults to ``0.0``.
+            skew_steepening: Optional deep-OTM skew steepening added on top of
+                ``crash_vol_shock`` at the tail (M1.6), single-sourced from
+                ``IpsConvexity.skew_steepening`` (pass
+                ``ctx.ips_config.convexity.skew_steepening``) so the ladder
+                shares the gauge's basis exactly. Defaults to ``0.0``.
 
         """
         self.portfolio = portfolio
         self._crash_vol_shock = crash_vol_shock
+        self._skew_steepening = skew_steepening
         self.widget = None
         self._create_widget()
 
@@ -83,6 +90,7 @@ class NetHedgeSummary:
                     self.portfolio,
                     crash_move=shock / 100.0,
                     vol_shock=self._crash_vol_shock,
+                    skew_steepening=self._skew_steepening,
                 ),
             )
             for shock in self._CRASH_RUNG_SHOCKS

--- a/docs/implementation-plan.md
+++ b/docs/implementation-plan.md
@@ -97,6 +97,11 @@ trigger stops firing spuriously. The §4 book ships as a loadable example
 (`examples/portfolios/spx_tail_20m.yaml`); the band assertion anchors on it, not on
 `spx_protective_put.yaml` (invariants only there).
 
+> **Superseded by M1.6.** The skew-aware shock recomputed these §4 anchors to
+> crash ≈ $4,788,166 (16.1×), convexity **+22.5%** (still in-band); V_today
+> ($297,715) and the intrinsic floor ($759,000) are unchanged. The flat values
+> above (+18.0% / 13.1×) are now pinned as the `skew=0.0` no-op proof.
+
 ### M1.3 — Decision-layer definitions (P1)
 
 **Status: done** — PR #194.
@@ -268,17 +273,47 @@ every commit, not just at the end.
 
 ### M1.6 — Skew-aware crash shock (deliberately *after* the correctness tag)
 
-**Status: specified, not started.** Sequenced post-tag on purpose: nothing
-currently fails (the canonical book asserts invariants only; the band test anchors
-on the §4 fixture), so there is no urgency, and doing it against a tagged baseline
-gives a clean before/after on a stable reference point.
+**Status: DONE (2026-07-21).** Landed on `feat/skew-aware-crash-shock` in two
+commits: `a639199` (mechanism, default off, byte-for-byte no-op proof) and
+`b29d750` (adopt `0.10`, wire the four book-convexity surfaces, recompute the §4
+goldens + methodology). Sequenced post-tag on purpose: nothing failed beforehand
+(the canonical book asserts invariants only; the band test anchors on the §4
+fixture), so doing it against a tagged baseline gave a clean before/after on a
+stable reference point.
+
+**Resolution (auditable close-out).**
+- **Calibration — signed off, from history alone.** `skew_steepening = 0.10`:
+  extra vol at the deepest OTM tail over ATM, weight **linear in log-moneyness**
+  `ln(S/K)` (0 at ATM → 1 at the deepest held put). Anchored on 2008/2020
+  index-put skew, where the ≈10-delta wing steepened **15+ vol points** over ATM at
+  the peak; 0.10 is a conservative central estimate (range 0.05–0.20), derived
+  before observing where the book lands (condition 1). See
+  `docs/repricing-methodology.md` §2/§5.
+- **Recomputed §4 goldens (skew-aware):** convexity **+18.0% → +22.5%**, payoff
+  **13.1× → 16.1×**, V_crash **$3,895,901 → $4,788,166**. V_today ($297,715) and
+  the intrinsic floor ($759,000) are unchanged — skew is a crash-state effect only.
+  The flat baseline is still pinned as the `skew=0.0` no-op proof.
+- **Canonical book re-measured — NO re-size.** `spx_protective_put.yaml` reads
+  **+16.55%** at −25% under the adopted shock (`crash_vol_shock` +0.15,
+  `skew_steepening` +0.10), **+1.55 pp above the +15% floor** — vs **+14.27%**
+  under the old flat bump (0.73 pp under). The honestly-calibrated shock lifts it
+  into band with margin, so the book is conformant and **no sizing change is made**
+  (honors the 2026-07-19 sign-off, "refine the shock, do not re-size").
+- **Deferred (documented follow-up):** sizing / strike-ladder / candidate stay on
+  the flat bump — they price *standalone* candidate strikes, where each candidate
+  would be its own tail and receive the full steepening (overstating shallow
+  payoffs → undersizing the hedge); wiring them needs a per-strike skew anchor.
+  Also deferred: the shock's **term structure** (M1.6 ships one cross-sectional
+  log-moneyness slope; tenor-dependence not modelled — methodology §8).
 
 **Motivation.** The shipped flat bump (`+0.15` on every leg) is documented-
 conservative on the low strikes (methodology §8): crash skew steepening is an
 empirical fact — deep-OTM puts reliably gain more IV than ATM in a sell-off.
 Measured on `spx_protective_put.yaml`: **+14.27%** flat vs **+15.4%** under a
 modest steepening (deep-OTM tail `+0.05` over ATM); `~+0.03` at the tail already
-clears the floor (14.97%).
+clears the floor (14.97%). *(These were exploratory sensitivities; the calibration
+signed off from 2008/2020 history was `+0.10`, under which the book reads **+16.55%**
+— see the Resolution block above.)*
 
 **Work.** Add an optional `convexity.skew_steepening` to the IPS, consumed by
 `analysis/crash_repricing`, lifting deep-OTM IV more than ATM. Zero steepening is

--- a/docs/repricing-methodology.md
+++ b/docs/repricing-methodology.md
@@ -34,7 +34,7 @@ band (+15% … +25% at −25%) is stated against. The numerator is the change in
 
 ---
 
-## 2. The crash state — flat vol-bump convention
+## 2. The crash state — skew-aware vol shock
 
 From today's state ($S_0$, each leg's $\sigma_i$, $r$, $q$, valuation date $t_0$),
 construct the crash state:
@@ -42,21 +42,41 @@ construct the crash state:
 | Quantity | Rule | Source |
 |---|---|---|
 | Crash spot | $S_{\text{crash}} = S_0 (1 + m)$ | `ips.crash.scenario_move` (default **−0.25**) |
-| Crash vol (per leg) | $\sigma_{i,\text{crash}} = \sigma_{i,\text{today}} + \Delta\sigma$ | `ips.crash.vol_shock` (default **+0.15**, flat & additive) |
+| Crash vol (per leg) | $\sigma_{i,\text{crash}} = \sigma_{i,\text{today}} + \Delta\sigma + \kappa\, w_i$ | `ips.crash.vol_shock` (**+0.15**, flat ATM base) + `ips.crash.skew_steepening` (**+0.10**, deep-OTM tail) |
 | Rate / dividend | held at today's values | — |
 | Time to maturity | **unchanged** ($t_0$ fixed) | — |
 | Engine | European closed form (QuantLib `AnalyticEuropeanEngine` = Black–Scholes) | README: American forbidden for SPX |
 
-The vol shock is **flat**: the same additive bump is applied to every leg's own
-today-vol. This is deliberately the simplest defensible convention (one number, one
-IPS knob, fully transparent). Its known limitation — no skew steepening — is
-documented in §8 and is *conservative* (it understates convexity on the lowest
-strikes).
+**The shock is skew-aware.** Every leg gets the flat additive bump $\Delta\sigma$
+(`vol_shock`, +0.15) at its own today-vol; deep-OTM puts get an *additional*
+steepening on top, up to $\kappa$ (`skew_steepening`, +0.10) at the deepest tail:
 
-**`ips.crash.scenario_move` is the single source of truth for the crash scenario**
-across every panel — the health gauge, the scenario table, and the roll-status
-trigger all read it. This removes the −20% / −25% split (**Mo1**); no panel carries
-its own crash constant.
+$$\sigma_{i,\text{crash}} = \sigma_{i,\text{today}} + \Delta\sigma + \kappa\, w_i,
+\qquad
+w_i = \begin{cases}
+\min\!\left(1,\; \dfrac{\ln(S_0/K_i)}{\ln(S_0/K_{\text{tail}})}\right) & K_i < S_0 \text{ (OTM put)}\\[1.2em]
+0 & \text{calls, ATM/ITM puts}
+\end{cases}$$
+
+The weight $w_i$ is **linear in log-moneyness** $\ln(S_0/K_i)$, measured against
+*today's* spot: $w = 0$ at ATM (and for calls / ITM puts, which do not steepen)
+and $w = 1$ at $K_{\text{tail}}$, the deepest OTM put held. Setting $\kappa = 0$
+recovers the flat bump exactly.
+
+**Calibration of $\kappa$.** In a real sell-off deep-OTM index puts gain *more* IV
+than ATM — the put wing steepens. In 2008 and 2020 the ≈10-delta wing steepened by
+**15+ vol points** over ATM at the peak (CBOE SKEW / index-put surface history).
+**+0.10** is a deliberately conservative central estimate (plausible range
++0.05…+0.20): understating the steepening errs toward *less* apparent protection,
+the safe direction for a tail program. It is calibrated from the historical
+episodes alone, not to any book's target band (see §5, and the M1.6 rationale in
+`docs/implementation-plan.md`).
+
+**`ips.crash.scenario_move`, `.vol_shock`, and `.skew_steepening` are each a single
+source of truth** across every crash panel — the health gauge, the scenario table,
+the summary ladder, and the roll-status trigger all read the same three knobs and
+the same book tail, so a crash number is identical across surfaces at equal depth.
+This removes the −20% / −25% split (**Mo1**); no panel carries its own constant.
 
 ---
 
@@ -64,9 +84,10 @@ its own crash constant.
 
 $$V_{\text{today}} = \sum_i \text{price}\big(S_0,\,K_i,\,\sigma_i,\,r,\,q,\,T_i,\,\text{style}_i\big)\cdot q_i \cdot c_i$$
 
-$$V_{\text{crash}} = \sum_i \text{price}\big(S_{\text{crash}},\,K_i,\,\sigma_i+\Delta\sigma,\,r,\,q,\,T_i,\,\text{style}_i\big)\cdot q_i \cdot c_i$$
+$$V_{\text{crash}} = \sum_i \text{price}\big(S_{\text{crash}},\,K_i,\,\sigma_i+\Delta\sigma+\kappa\, w_i,\,r,\,q,\,T_i,\,\text{style}_i\big)\cdot q_i \cdot c_i$$
 
-where $q_i$ = signed contract quantity, $c_i$ = contract size, $T_i$ unchanged.
+where $q_i$ = signed contract quantity, $c_i$ = contract size, $T_i$ unchanged,
+and the per-leg skew weight $w_i$ is defined in §2 ($\kappa = 0$ gives the flat bump).
 Reprice via the **existing** `OptionValuation` / `BatchPricer` — do not add a new
 pricer.
 
@@ -76,7 +97,7 @@ headline number):
 $$V_{\text{crash}}^{\text{floor}} = \sum_i \max\big(\phi_i (K_i - S_{\text{crash}}),\,0\big)\cdot q_i \cdot c_i \quad (\phi=1 \text{ for puts})$$
 
 The floor is the conservative lower bound the docstrings intended; §4 shows why it
-must not be the headline (it reads 2.5× where the repriced value is 13×).
+must not be the headline (it reads 2.5× where the repriced value is 16×).
 
 ---
 
@@ -86,25 +107,37 @@ A conformant $20M book: three-rung 20/30/40%-OTM ladder, 18-month tenor,
 weighted 35/40/25 by contract count, carry ≈ 1%.
 
 **Inputs:** $S_0 = 6600$, $m = -0.25 \Rightarrow S_{\text{crash}} = 4950$;
-today vol $20\%$ (flat, illustrative), $\Delta\sigma = +0.15 \Rightarrow$ crash vol
-$35\%$; $r = 4.5\%$, $q = 1.5\%$, $T = 1.5$y, contract size 100, European puts.
+today vol $20\%$ (flat, illustrative); $r = 4.5\%$, $q = 1.5\%$, $T = 1.5$y,
+contract size 100, European puts. Crash vol is the flat base
+$\Delta\sigma = +0.15$ (35% at ATM) **plus** the skew steepening $\kappa = +0.10$
+weighted by log-moneyness — the tail anchor is the deepest put (3960), so
+$w = \ln(6600/K)/\ln(6600/3960)$ gives crash vols **39.4% / 42.0% / 45.0%** across
+the 20/30/40%-OTM rungs.
 
-| Leg | Strike | Qty | Price today | Price crash | Intrinsic (crash) | Value today | Value crash |
-|---|---|---|---|---|---|---|---|
-| 20% OTM | 5280 | 23 | 95.39 | 878.08 | 330.00 | \$219,392 | \$2,019,573 |
-| 30% OTM | 4620 | 26 | 27.19 | 543.28 | 0.00 | \$70,696 | \$1,412,536 |
-| 40% OTM | 3960 | 16 | 4.77 | 289.87 | 0.00 | \$7,627 | \$463,792 |
-| **Hedge** | | | | | | **\$297,715** | **\$3,895,901** |
+| Leg | Strike | Qty | $w$ | Crash vol | Price today | Price crash | Intrinsic (crash) | Value today | Value crash |
+|---|---|---|---|---|---|---|---|---|---|
+| 20% OTM | 5280 | 23 | 0.44 | 39.4% | 95.39 | 979.62 | 330.00 | \$219,392 | \$2,253,133 |
+| 30% OTM | 4620 | 26 | 0.70 | 42.0% | 27.19 | 690.56 | 0.00 | \$70,696 | \$1,795,458 |
+| 40% OTM | 3960 | 16 | 1.00 | 45.0% | 4.77 | 462.23 | 0.00 | \$7,627 | \$739,575 |
+| **Hedge** | | | | | | | | **\$297,715** | **\$4,788,166** |
 
-- Hedge value today **\$297,715** — 1.49% of the \$20M book, ≈ **0.99%/yr** carry.
-- Hedge value in crash **\$3,895,901** (repriced) — a **13.1×** multiple.
+- Hedge value today **\$297,715** — 1.49% of the \$20M book, ≈ **0.99%/yr** carry
+  (skew is a crash-state effect, so $V_{\text{today}}$ is unchanged from the flat
+  bump).
+- Hedge value in crash **\$4,788,166** (repriced) — a **16.1×** multiple.
 - Intrinsic floor **\$759,000** — only **2.5×**, and it zeroes the 30% and 40% legs.
 
-$$\text{convexity} = \frac{3{,}895{,}901 - 297{,}715}{20{,}000{,}000} = \mathbf{+18.0\%} \;\Rightarrow\; \textbf{inside the IPS +15\%…+25\% band.}$$
+$$\text{convexity} = \frac{4{,}788{,}166 - 297{,}715}{20{,}000{,}000} = \mathbf{+22.5\%} \;\Rightarrow\; \textbf{inside the IPS +15\%…+25\% band.}$$
 
-**The bug, for contrast:** the intrinsic-only basis gives
-$(759{,}000 - 297{,}715)/20{,}000{,}000 = \mathbf{+2.3\%}$ — and the current code
-further nets the equity loss on top, which is how a conformant book reads as
+**Before/after (M1.6).** Under the pre-M1.6 *flat* $+0.15$ bump (every leg at 35%
+crash vol) this same book read $V_{\text{crash}} = \$3{,}895{,}901$, a **13.1×**
+multiple and **+18.0%** convexity. The skew-aware shock lifts the deep-OTM legs
+(where the wing genuinely steepens in a crash), adding ≈4.5 pp of convexity — the
+flat bump *understated* it. Both readings sit inside the +15%…+25% band.
+
+**The intrinsic bug, for contrast:** the intrinsic-only basis gives
+$(759{,}000 - 297{,}715)/20{,}000{,}000 = \mathbf{+2.3\%}$ — and the pre-M1.2 code
+further netted the equity loss on top, which is how a conformant book once read as
 *failing* on every row.
 
 > Prices are Black–Scholes European; QuantLib's `AnalyticEuropeanEngine` returns the
@@ -114,18 +147,26 @@ further nets the equity loss on top, which is how a conformant book reads as
 
 ---
 
-## 5. IPS parameters to add
+## 5. IPS parameters
 
 | Key | Default | Notes |
 |---|---|---|
 | `ips.crash.scenario_move` | `-0.25` | **Single source** for every crash panel (Mo1). |
-| `ips.crash.vol_shock` | `+0.15` | Flat additive bump. See calibration note. |
+| `ips.crash.vol_shock` | `+0.15` | Flat additive bump (ATM base). See calibration note. |
+| `ips.crash.skew_steepening` | `+0.10` | Extra vol at the deep-OTM tail over ATM, linear in log-moneyness (M1.6). `0.0` recovers the flat bump. See calibration note. |
 | `ips.crash.floor_reported` | `true` | Whether to surface the intrinsic-floor column. |
 
 **Calibration note for `vol_shock`.** In 2008 and 2020, index-put implied vols
 expanded roughly **+20 to +40 points** at the peak. **+15** is a deliberately
-conservative, mid-cycle baseline — set it to your own crash-vol view. It is a
+conservative, mid-cycle ATM baseline — set it to your own crash-vol view. It is a
 policy input, so it belongs in the IPS, not in presentation config.
+
+**Calibration note for `skew_steepening`.** The flat bump lifts every leg equally;
+in a real crash the deep-OTM wing steepens *above* ATM. In 2008/2020 the ≈10-delta
+put wing ran **15+ vol points** over ATM at the peak; **+0.10** is a conservative
+central estimate (range +0.05…+0.20) derived from those episodes alone — never
+tuned to a book's target band (M1.6 condition 1). Understating it errs toward less
+apparent protection, the safe direction for a tail program.
 
 ---
 
@@ -146,29 +187,41 @@ policy input, so it belongs in the IPS, not in presentation config.
 
 ## 7. Acceptance tests (normative)
 
-1. **Golden values** — the §4 portfolio reprices to $V_{\text{today}}$ and
-   $V_{\text{crash}}$ within tolerance; convexity = **+18.0% ± ε**.
+1. **Golden values** — the §4 portfolio reprices to $V_{\text{today}} = \$297{,}715$
+   and $V_{\text{crash}} = \$4{,}788{,}166$ within tolerance; convexity =
+   **+22.5% ± ε** (skew-aware shock). A separate no-op test pins the flat baseline
+   at $\kappa = 0$: **+18.0%**, $V_{\text{crash}} = \$3{,}895{,}901$.
 2. **Band** — the canonical example (`examples/portfolios/spx_protective_put.yaml`)
-   yields convexity within **+15%…+25%** at −25%; `meets_target` is `True` on every
-   scenario row.
+   yields convexity within **+15%…+25%** at −25%. Under the flat bump it read
+   **+14.27%** (just under the floor); the honestly-calibrated skew shock lifts it
+   to **+16.55%**, comfortably in-band — **so no re-size is needed** (the M1.6
+   "record the re-size decision either way" outcome).
 3. **Hedge-only invariant** — adding or removing the equity leg does **not** change
    convexity (guards against C1 regressing).
 4. **Repriced invariant** — the 30% and 40% OTM legs contribute **> 0** at −25%
    (guards against C4 regressing); the intrinsic-floor column is strictly less than
    the repriced value for any strike beyond the crash move.
-5. **Single-source** — changing `ips.crash.scenario_move` moves the health gauge,
-   the scenario table, and the roll trigger together.
+5. **Single-source** — changing `ips.crash.scenario_move`, `.vol_shock`, or
+   `.skew_steepening` moves the health gauge, the scenario table, the summary
+   ladder, and the roll trigger together (identical at equal depth).
 
 ---
 
 ## 8. Known simplifications (documented, not defects)
 
-- **No skew steepening.** A flat bump gives every leg the same +Δσ; in a real crash
-  the deep-OTM puts gain *more* IV than ATM. This **understates** convexity on the
-  lowest strikes → conservative. A skew-aware shock (`ips.crash.skew_steepening`) is
-  the natural next refinement.
+- **Skew steepening — implemented (M1.6).** The deep-OTM wing now steepens above
+  ATM via `ips.crash.skew_steepening` (§2), so the shock no longer understates
+  convexity on the lowest strikes. Two limitations remain in the model:
+  - **Single-slope, cross-sectional.** The steepening is one linear-in-log-moneyness
+    slope $\kappa$ anchored at the deepest held put; it does not model the *term*
+    structure of skew (how the slope varies with tenor) — a natural next refinement.
+  - **Book-convexity surfaces only.** The gauge, roll trigger, summary ladder, and
+    scenario table read the skew shock; the **sizing / strike-ladder / candidate**
+    path stays on the flat bump for now, because pricing a *standalone* candidate as
+    its own tail would over-apply the steepening and undersize the hedge. Wiring it
+    correctly needs a per-strike skew anchor (deferred, tracked follow-up).
 - **Rates / dividends held constant.** Rates typically fall in a crash; the effect
-  is second-order for long puts and is out of scope for the flat baseline.
+  is second-order for long puts and is out of scope for this baseline.
 - **Single instantaneous horizon.** The crash is modelled as one jump at $t_0$; the
   term structure of a crash path is not modelled here (that is the Monte Carlo
   surface's job — see M3).

--- a/examples/ips/ips_default.yaml
+++ b/examples/ips/ips_default.yaml
@@ -26,6 +26,9 @@ convexity:
   target_min_pct: 15.0
   target_max_pct: 25.0
   crash_vol_shock: 0.15         # flat additive vol bump at the crash spot (M1.2)
+  skew_steepening: 0.10         # extra vol at the deep-OTM tail over ATM, linear
+                                # in log-moneyness (M1.6; methodology §2). 0.0
+                                # keeps the flat bump.
   crash_floor_reported: true    # surface the intrinsic-floor column
 
 drawdown:

--- a/examples/portfolios/spx_tail_20m.yaml
+++ b/examples/portfolios/spx_tail_20m.yaml
@@ -6,14 +6,18 @@
 # (SPX is cash-settled). This is the methodology's reproducible worked example —
 # an in-band book to open in the monitor for demos and smoke checks.
 #
-# Golden values (§4, flat +0.15 crash vol shock, -25% crash, T = 1.5y):
+# Golden values (§4, skew-aware crash shock, -25% crash, T = 1.5y): flat +0.15
+# vol bump at ATM plus a +0.10 deep-OTM skew steepening linear in log-moneyness,
+# so crash vols run 39.4% / 42.0% / 45.0% across the 20/30/40%-OTM rungs (M1.6):
 #   Hedge value today   ≈ $297,715   (1.49% of $20M, ≈ 0.99%/yr carry)
-#   Hedge value in crash ≈ $3,895,901 (13.1x — repriced, full option value)
-#   Convexity           ≈ +18.0%     -> inside the IPS +15%..+25% band
+#   Hedge value in crash ≈ $4,788,166 (16.1x — repriced, full option value)
+#   Convexity           ≈ +22.5%     -> inside the IPS +15%..+25% band
+# (Under the pre-M1.6 flat +0.15 bump this book read +18.0% / 13.1x.)
 #
 # Maturities are relative (maturity_days: 548 ≈ 18 months) so the book stays a
 # stable ~1.5y-tenor fixture whenever it is opened, not a decaying snapshot.
-# Vol is a flat 20% across strikes (illustrative, per §4 — no skew here).
+# Today-vol is a flat 20% across strikes (illustrative, per §4); the skew enters
+# only in the crash state, lifting the deep-OTM wing above ATM.
 
 # Market Parameters
 market_parameters:

--- a/tests/test_analysis/test_crash_payoff.py
+++ b/tests/test_analysis/test_crash_payoff.py
@@ -232,6 +232,7 @@ class TestComputeCrashConvexity:
             *,
             crash_move: float,
             vol_shock: float,
+            skew_steepening: float = 0.0,
             positions: object = None,
         ) -> float:
             calls.append(round(crash_move * 100.0, 6))
@@ -239,6 +240,7 @@ class TestComputeCrashConvexity:
                 portfolio,
                 crash_move=crash_move,
                 vol_shock=vol_shock,
+                skew_steepening=skew_steepening,
                 positions=positions,
             )
 

--- a/tests/test_analysis/test_crash_repricing.py
+++ b/tests/test_analysis/test_crash_repricing.py
@@ -11,6 +11,7 @@ the summary crash-convexity ladder.
 from __future__ import annotations
 
 import inspect
+import math
 from datetime import UTC, datetime, timedelta
 from pathlib import Path
 
@@ -76,6 +77,33 @@ def _make_appendix_book(
             option_type=OptionType.PUT,
             volatility=0.20,
         )
+    return portfolio
+
+
+def _make_call_book() -> OptionPortfolio:
+    """A long-call book with no OTM put — the skew knob has no wing to anchor.
+
+    Returns:
+        A portfolio holding a single OTM call at the appendix spot/tenor.
+    """
+    valuation_date = datetime(2026, 1, 2, tzinfo=UTC)
+    maturity = valuation_date + timedelta(days=round(1.5 * 365))
+    portfolio = OptionPortfolio(
+        spot_price=_APPENDIX_SPOT,
+        volatility=0.20,
+        risk_free_rate=0.045,
+        dividend_yield=0.015,
+        underlying_quantity=_APPENDIX_BOOK / _APPENDIX_SPOT,
+        default_exercise_style=ExerciseStyle.EUROPEAN,
+        valuation_date=valuation_date,
+    )
+    portfolio.add_position(
+        strike_price=7260.0,
+        maturity_date=maturity,
+        quantity=10,
+        option_type=OptionType.CALL,
+        volatility=0.20,
+    )
     return portfolio
 
 
@@ -169,6 +197,164 @@ class TestAppendixGoldenValues:
             crash_move=_APPENDIX_MOVE,
             vol_shock=_APPENDIX_VOL_SHOCK,
         )
+
+
+class TestSkewSteepeningNoOp:
+    """M1.6 — the optional skew_steepening knob is a no-op when ``0.0``.
+
+    Proves the refactor changes nothing while disabled: an explicit
+    ``skew_steepening=0.0`` reproduces the parameter-omitted call byte-for-byte,
+    and every §4 golden anchor still lands. This must hold before any golden is
+    recomputed under a positive steepening (M1.6 sequencing).
+    """
+
+    def test_crash_hedge_value_noop(self) -> None:
+        """``$3,895,901`` V_crash is unchanged by ``skew_steepening=0.0``."""
+        portfolio = _make_appendix_book()
+
+        base = cr.crash_hedge_value(
+            portfolio,
+            crash_move=_APPENDIX_MOVE,
+            vol_shock=_APPENDIX_VOL_SHOCK,
+        )
+        with_knob = cr.crash_hedge_value(
+            portfolio,
+            crash_move=_APPENDIX_MOVE,
+            vol_shock=_APPENDIX_VOL_SHOCK,
+            skew_steepening=0.0,
+        )
+
+        assert with_knob == base
+        assert with_knob == pytest.approx(3_895_901.0, rel=0.005)
+
+    def test_crash_convexity_pct_noop(self) -> None:
+        """``+18.0%`` convexity is unchanged by ``skew_steepening=0.0``."""
+        portfolio = _make_appendix_book()
+
+        base = cr.crash_convexity_pct(
+            portfolio,
+            crash_move=_APPENDIX_MOVE,
+            vol_shock=_APPENDIX_VOL_SHOCK,
+        )
+        with_knob = cr.crash_convexity_pct(
+            portfolio,
+            crash_move=_APPENDIX_MOVE,
+            vol_shock=_APPENDIX_VOL_SHOCK,
+            skew_steepening=0.0,
+        )
+
+        assert with_knob == base
+        assert with_knob == pytest.approx(18.0, abs=0.5)
+
+    def test_payoff_ratio_unchanged(self) -> None:
+        """The ``13.1x`` payoff anchor is untouched by the knob."""
+        portfolio = _make_appendix_book()
+        ips = IpsConvexity(
+            crash_scenario_pct=-25.0,
+            target_min_pct=15.0,
+            target_max_pct=25.0,
+            crash_vol_shock=_APPENDIX_VOL_SHOCK,
+        )
+
+        result = compute_crash_convexity(
+            portfolio,
+            crash_vol_shock=_APPENDIX_VOL_SHOCK,
+            ips_convexity=ips,
+        )
+
+        assert result.payoff_ratio == pytest.approx(13.1, rel=0.02)
+
+    def test_intrinsic_floor_is_vol_independent(self) -> None:
+        """The ``$759,000`` intrinsic floor is vol-independent."""
+        portfolio = _make_appendix_book()
+
+        floor = cr.crash_intrinsic_floor(portfolio, crash_move=_APPENDIX_MOVE)
+
+        assert floor == pytest.approx(759_000.0, rel=0.005)
+
+
+class TestSkewSteepeningBehaviour:
+    """M1.6 — a positive skew_steepening lifts deep-OTM put vol above ATM."""
+
+    def test_steepening_raises_crash_hedge_value(self) -> None:
+        """Long OTM puts gain IV under steepening, so V_crash rises."""
+        portfolio = _make_appendix_book()
+
+        flat = cr.crash_hedge_value(
+            portfolio,
+            crash_move=_APPENDIX_MOVE,
+            vol_shock=_APPENDIX_VOL_SHOCK,
+        )
+        steepened = cr.crash_hedge_value(
+            portfolio,
+            crash_move=_APPENDIX_MOVE,
+            vol_shock=_APPENDIX_VOL_SHOCK,
+            skew_steepening=0.10,
+        )
+
+        assert steepened > flat
+
+    def test_weights_are_linear_in_log_moneyness(self) -> None:
+        """V_crash matches the leg vols rebuilt from the log-moneyness form.
+
+        Independently reconstructs each leg's shocked vol as
+        ``0.20 + vol_shock + skew * w`` with ``w = ln(S/K) / ln(S/K_tail)``,
+        prices with the public engine, and requires an exact match — pinning
+        the interpolation to log-moneyness with the deepest OTM put as anchor.
+        """
+        portfolio = _make_appendix_book()
+        skew = 0.10
+
+        got = cr.crash_hedge_value(
+            portfolio,
+            crash_move=_APPENDIX_MOVE,
+            vol_shock=_APPENDIX_VOL_SHOCK,
+            skew_steepening=skew,
+        )
+
+        crash_spot = _APPENDIX_SPOT * (1.0 + _APPENDIX_MOVE)
+        deepest_strike = min(strike for strike, _ in _APPENDIX_LEGS)
+        tail_log_moneyness = math.log(_APPENDIX_SPOT / deepest_strike)
+        expected = 0.0
+        for position in portfolio.positions:
+            strike = position.option.strike_price
+            weight = min(
+                1.0,
+                math.log(_APPENDIX_SPOT / strike) / tail_log_moneyness,
+            )
+            vol = 0.20 + _APPENDIX_VOL_SHOCK + skew * weight
+            leg = OptionValuation(
+                spot_price=crash_spot,
+                strike_price=strike,
+                maturity_date=position.option.maturity_date,
+                volatility=vol,
+                risk_free_rate=portfolio.risk_free_rate,
+                dividend_yield=portfolio.dividend_yield,
+                option_type=position.option.option_type,
+                valuation_date=portfolio.valuation_date,
+                exercise_style=position.exercise_style,
+            )
+            expected += leg.price() * position.quantity * position.contract_size
+
+        assert got == pytest.approx(expected, rel=1e-9)
+
+    def test_no_otm_put_means_no_steepening(self) -> None:
+        """With no OTM put to anchor the wing, the knob is inert."""
+        portfolio = _make_call_book()
+
+        flat = cr.crash_hedge_value(
+            portfolio,
+            crash_move=_APPENDIX_MOVE,
+            vol_shock=_APPENDIX_VOL_SHOCK,
+        )
+        steepened = cr.crash_hedge_value(
+            portfolio,
+            crash_move=_APPENDIX_MOVE,
+            vol_shock=_APPENDIX_VOL_SHOCK,
+            skew_steepening=0.10,
+        )
+
+        assert steepened == flat
 
 
 class TestBand:

--- a/tests/test_analysis/test_crash_repricing.py
+++ b/tests/test_analysis/test_crash_repricing.py
@@ -35,6 +35,9 @@ _APPENDIX_SPOT = 6600.0
 _APPENDIX_BOOK = 20_000_000.0
 _APPENDIX_MOVE = -0.25
 _APPENDIX_VOL_SHOCK = 0.15
+# Shipped deep-OTM skew steepening (M1.6): extra vol at the deepest tail over
+# ATM, linear in log-moneyness. The §4 worked example is now skew-aware.
+_APPENDIX_SKEW = 0.10
 # (strike, contract count) for the 20/30/40%-OTM three-rung ladder.
 _APPENDIX_LEGS = ((5280.0, 23), (4620.0, 26), (3960.0, 16))
 
@@ -138,10 +141,15 @@ def _load_golden_20m_example() -> OptionPortfolio:
 
 
 class TestAppendixGoldenValues:
-    """§7.1 — the §4 worked example reprices to the published figures."""
+    """§7.1 — the §4 worked example reprices to the published figures.
+
+    The shipped shock is skew-aware (``_APPENDIX_SKEW``); these anchors are the
+    post-M1.6 §4 goldens. The flat-bump baseline (``+18.0%`` / ``13.1x``) is
+    pinned separately by :class:`TestSkewSteepeningNoOp` at ``skew=0.0``.
+    """
 
     def test_hedge_values_within_tolerance(self) -> None:
-        """V_today and V_crash sit within ~0.5% of the §4 table."""
+        """V_today and V_crash sit within ~0.5% of the skew-aware §4 table."""
         portfolio = _make_appendix_book()
 
         v_today = cr.hedge_value(portfolio)
@@ -149,41 +157,46 @@ class TestAppendixGoldenValues:
             portfolio,
             crash_move=_APPENDIX_MOVE,
             vol_shock=_APPENDIX_VOL_SHOCK,
+            skew_steepening=_APPENDIX_SKEW,
         )
 
+        # V_today is skew-free (skew is a crash-state effect only).
         assert v_today == pytest.approx(297_715.0, rel=0.005)
-        assert v_crash == pytest.approx(3_895_901.0, rel=0.005)
+        assert v_crash == pytest.approx(4_788_166.0, rel=0.005)
 
-    def test_convexity_is_plus_18_pct(self) -> None:
-        """Crash convexity is +18.0% ± epsilon — inside the IPS band."""
+    def test_convexity_is_plus_22_pct(self) -> None:
+        """Crash convexity is +22.5% ± epsilon — inside the IPS band."""
         portfolio = _make_appendix_book()
 
         convexity = cr.crash_convexity_pct(
             portfolio,
             crash_move=_APPENDIX_MOVE,
             vol_shock=_APPENDIX_VOL_SHOCK,
+            skew_steepening=_APPENDIX_SKEW,
         )
 
-        assert convexity == pytest.approx(18.0, abs=0.5)
+        assert convexity == pytest.approx(22.5, abs=0.5)
 
-    def test_payoff_ratio_is_about_13x(self) -> None:
-        """The repriced headline payoff ratio is ~13x (not the 2.5x floor)."""
+    def test_payoff_ratio_is_about_16x(self) -> None:
+        """The repriced headline payoff ratio is ~16x (not the 2.5x floor)."""
         portfolio = _make_appendix_book()
         ips = IpsConvexity(
             crash_scenario_pct=-25.0,
             target_min_pct=15.0,
             target_max_pct=25.0,
             crash_vol_shock=_APPENDIX_VOL_SHOCK,
+            skew_steepening=_APPENDIX_SKEW,
         )
 
         result = compute_crash_convexity(
             portfolio,
             crash_vol_shock=_APPENDIX_VOL_SHOCK,
+            skew_steepening=_APPENDIX_SKEW,
             ips_convexity=ips,
         )
 
         assert result.payoff_ratio is not None
-        assert result.payoff_ratio == pytest.approx(13.1, rel=0.02)
+        assert result.payoff_ratio == pytest.approx(16.1, rel=0.02)
 
     def test_intrinsic_floor_is_the_conservative_759k(self) -> None:
         """The intrinsic floor (~$759k) is far below the repriced value."""
@@ -191,11 +204,13 @@ class TestAppendixGoldenValues:
 
         floor = cr.crash_intrinsic_floor(portfolio, crash_move=_APPENDIX_MOVE)
 
+        # The floor is vol/skew-independent (pure intrinsic at the crash spot).
         assert floor == pytest.approx(759_000.0, rel=0.005)
         assert floor < cr.crash_hedge_value(
             portfolio,
             crash_move=_APPENDIX_MOVE,
             vol_shock=_APPENDIX_VOL_SHOCK,
+            skew_steepening=_APPENDIX_SKEW,
         )
 
 
@@ -368,11 +383,13 @@ class TestBand:
             target_min_pct=15.0,
             target_max_pct=25.0,
             crash_vol_shock=_APPENDIX_VOL_SHOCK,
+            skew_steepening=_APPENDIX_SKEW,
         )
 
         result = compute_crash_convexity(
             portfolio,
             crash_vol_shock=_APPENDIX_VOL_SHOCK,
+            skew_steepening=_APPENDIX_SKEW,
             ips_convexity=ips,
         )
         ips_row = next(r for r in result.scenario_rows if r.shock_pct == -25.0)
@@ -403,22 +420,24 @@ class TestGoldenExampleFile:
             portfolio,
             crash_move=_APPENDIX_MOVE,
             vol_shock=_APPENDIX_VOL_SHOCK,
+            skew_steepening=_APPENDIX_SKEW,
         )
 
         assert v_today == pytest.approx(297_715.0, rel=0.005)
-        assert v_crash == pytest.approx(3_895_901.0, rel=0.005)
+        assert v_crash == pytest.approx(4_788_166.0, rel=0.005)
 
     def test_example_convexity_is_in_band(self) -> None:
-        """Loaded book reprices to +18.0% ± epsilon — inside +15..+25%."""
+        """Loaded book reprices to +22.5% ± epsilon — inside +15..+25%."""
         portfolio = _load_golden_20m_example()
 
         convexity = cr.crash_convexity_pct(
             portfolio,
             crash_move=_APPENDIX_MOVE,
             vol_shock=_APPENDIX_VOL_SHOCK,
+            skew_steepening=_APPENDIX_SKEW,
         )
 
-        assert convexity == pytest.approx(18.0, abs=0.5)
+        assert convexity == pytest.approx(22.5, abs=0.5)
         assert 15.0 <= convexity <= 25.0
 
 
@@ -528,25 +547,36 @@ class TestRepricedInvariant:
 
 
 class TestConsistencyAcrossSurfaces:
-    """§7.5 — one basis: gauge == scenario table == summary ladder."""
+    """§7.5 — one basis: gauge == scenario table == summary ladder.
+
+    Exercised under the shipped skew-aware shock (``_APPENDIX_SKEW``): every
+    surface reads the same ``IpsConvexity.skew_steepening`` and the same book
+    tail, so the deep-OTM steepening must reach them identically.
+    """
 
     def test_summary_rung_equals_health_gauge_and_helper(self) -> None:
         """The summary -20% rung equals the gauge and the helper exactly."""
         portfolio = _make_appendix_book()
         vol_shock = _APPENDIX_VOL_SHOCK
 
-        summary = NetHedgeSummary(portfolio, crash_vol_shock=vol_shock)
+        summary = NetHedgeSummary(
+            portfolio,
+            crash_vol_shock=vol_shock,
+            skew_steepening=_APPENDIX_SKEW,
+        )
         rungs = dict(summary._crash_convexity_rungs())
 
         analyzer = PortfolioAnalyzer(portfolio)
         gauge = analyzer.calculate_crash_convexity_pct(
             crash_scenario_pct=-20.0,
             crash_vol_shock=vol_shock,
+            skew_steepening=_APPENDIX_SKEW,
         )
         helper = cr.crash_convexity_pct(
             portfolio,
             crash_move=-0.20,
             vol_shock=vol_shock,
+            skew_steepening=_APPENDIX_SKEW,
         )
 
         assert rungs[-20.0] == pytest.approx(gauge)
@@ -560,17 +590,20 @@ class TestConsistencyAcrossSurfaces:
             target_min_pct=15.0,
             target_max_pct=25.0,
             crash_vol_shock=_APPENDIX_VOL_SHOCK,
+            skew_steepening=_APPENDIX_SKEW,
         )
 
         result = compute_crash_convexity(
             portfolio,
             crash_vol_shock=_APPENDIX_VOL_SHOCK,
+            skew_steepening=_APPENDIX_SKEW,
             ips_convexity=ips,
         )
         ips_row = next(r for r in result.scenario_rows if r.shock_pct == -25.0)
         gauge = PortfolioAnalyzer(portfolio).calculate_crash_convexity_pct(
             crash_scenario_pct=-25.0,
             crash_vol_shock=_APPENDIX_VOL_SHOCK,
+            skew_steepening=_APPENDIX_SKEW,
         )
 
         assert ips_row.convexity_pct == pytest.approx(gauge)

--- a/tests/test_analysis/test_roll_planner.py
+++ b/tests/test_analysis/test_roll_planner.py
@@ -108,6 +108,7 @@ def _patch_convexity(
         self: object,
         crash_scenario_pct: float,
         crash_vol_shock: float,
+        skew_steepening: float = 0.0,
     ) -> float:
         return value
 

--- a/tests/test_analysis/test_roll_status.py
+++ b/tests/test_analysis/test_roll_status.py
@@ -289,6 +289,7 @@ class TestEvaluateRollStatus:
             self,
             crash_scenario_pct: float,
             crash_vol_shock: float,
+            skew_steepening: float = 0.0,
         ) -> float:
             return value
 

--- a/tests/test_ips_config.py
+++ b/tests/test_ips_config.py
@@ -70,6 +70,7 @@ class TestLoadIpsConfig:
         assert ips.convexity.target_min_pct == 15.0
         assert ips.convexity.target_max_pct == 25.0
         assert ips.convexity.crash_vol_shock == 0.15
+        assert ips.convexity.skew_steepening == 0.0
         assert ips.convexity.crash_floor_reported is True
         assert ips.drawdown.max_tolerance_pct == 20.0
         assert ips.triggers.target_delta_ratio_pct == 90.0
@@ -162,6 +163,7 @@ class TestLoadIpsConfig:
         ips = load_ips_config(path)
 
         assert ips.convexity.crash_vol_shock == 0.15
+        assert ips.convexity.skew_steepening == 0.0
         assert ips.convexity.crash_floor_reported is True
 
     def test_crash_knobs_round_trip_when_set(self, tmp_path: Path) -> None:
@@ -173,6 +175,7 @@ class TestLoadIpsConfig:
                 "target_min_pct": 15.0,
                 "target_max_pct": 25.0,
                 "crash_vol_shock": 0.20,
+                "skew_steepening": 0.30,
                 "crash_floor_reported": False,
             },
         }
@@ -181,6 +184,7 @@ class TestLoadIpsConfig:
         ips = load_ips_config(path)
 
         assert ips.convexity.crash_vol_shock == 0.20
+        assert ips.convexity.skew_steepening == 0.30
         assert ips.convexity.crash_floor_reported is False
 
     def test_negative_crash_vol_shock_raises(self, tmp_path: Path) -> None:
@@ -197,6 +201,22 @@ class TestLoadIpsConfig:
         path = _write_yaml(tmp_path, config)
 
         with pytest.raises(IpsConfigError, match="crash_vol_shock"):
+            load_ips_config(path)
+
+    def test_negative_skew_steepening_raises(self, tmp_path: Path) -> None:
+        """A negative skew_steepening raises IpsConfigError."""
+        config = {
+            **_VALID_CONFIG,
+            "convexity": {
+                "crash_scenario_pct": -25.0,
+                "target_min_pct": 15.0,
+                "target_max_pct": 25.0,
+                "skew_steepening": -0.05,
+            },
+        }
+        path = _write_yaml(tmp_path, config)
+
+        with pytest.raises(IpsConfigError, match="skew_steepening"):
             load_ips_config(path)
 
     def test_negative_budget_raises(self, tmp_path: Path) -> None:

--- a/tests/test_ips_config.py
+++ b/tests/test_ips_config.py
@@ -70,7 +70,8 @@ class TestLoadIpsConfig:
         assert ips.convexity.target_min_pct == 15.0
         assert ips.convexity.target_max_pct == 25.0
         assert ips.convexity.crash_vol_shock == 0.15
-        assert ips.convexity.skew_steepening == 0.0
+        # M1.6: the shipped default adopts the skew-calibrated crash shock.
+        assert ips.convexity.skew_steepening == 0.10
         assert ips.convexity.crash_floor_reported is True
         assert ips.drawdown.max_tolerance_pct == 20.0
         assert ips.triggers.target_delta_ratio_pct == 90.0


### PR DESCRIPTION
## M1.6 — Skew-aware crash shock

Replaces the flat `+0.15` crash vol bump with a **skew-aware** shock: deep-OTM puts
gain more IV than ATM in a crash, which the flat bump understated (methodology §8).
Closes M1.6 in `docs/implementation-plan.md`.

### Calibration (derived from history, not tuned to any book)

`skew_steepening = 0.10` — extra vol at the deepest OTM tail over ATM, **linear in
log-moneyness** `ln(S/K)` (0 at ATM → 1 at the deepest held put). Anchored on
2008/2020 index-put skew, where the ≈10-delta wing steepened **15+ vol points** over
ATM at the peak; 0.10 is a deliberately conservative central estimate (range
0.05–0.20). Understating it errs toward less apparent protection — the safe
direction for a tail program. (M1.6 condition 1: calibrate independently, *then*
observe where the book lands.)

### What changed

- **`a639199`** — mechanism, **default off**. New `convexity.skew_steepening`
  (default 0.0, validated ≥ 0); `crash_repricing` computes each leg's crash vol as
  `crash_vol_shock + skew_steepening·w`. A **byte-for-byte no-op proof** pins that
  at `skew=0.0` every §4 number is unchanged (`+18.0%`, `13.1×`, `$3,895,901`,
  `$759,000`).
- **`b29d750`** — adopt `0.10` as the shipped default (`config/ips.yaml` +
  `examples/ips/ips_default.yaml`); wire it through the four book-convexity surfaces
  (health gauge, roll trigger, summary ladder, crash_payoff scenario table) from a
  single `IpsConvexity.skew_steepening`; recompute the §4 goldens and rewrite
  methodology §2/§3/§4/§5/§7/§8.
- **`002aceb`** — close M1.6 in the implementation plan with the canonical
  measurement and re-size decision below.

### Recomputed §4 goldens (skew-aware)

| | flat (was) | skew 0.10 (now) |
|---|---|---|
| V_crash | $3,895,901 | **$4,788,166** |
| Convexity | +18.0% | **+22.5%** (in-band) |
| Payoff | 13.1× | **16.1×** |

V_today ($297,715) and the intrinsic floor ($759,000) are unchanged — skew is a
crash-state effect only.

### Canonical book — re-size decision

`spx_protective_put.yaml` read **+14.27%** under the flat bump (0.73 pp under the
+15% floor); under the adopted skew it reads **+16.55%** — in-band by +1.55 pp.
**No re-size needed:** the honest calibration corrects a genuine under-statement
rather than the book being under-sized (honors the 2026-07-19 sign-off, "refine the
shock, do not re-size").

### Decisions deferred (documented)

- **Sizing / strike-ladder / candidate stay on the flat bump.** They price
  *standalone* candidate strikes, where each candidate would become its own tail and
  receive the full steepening → overstates shallow-candidate payoff → undersizes the
  hedge. Correct wiring needs a per-strike skew anchor. Tracked as follow-up.
- **Term structure of the shock** — one cross-sectional log-moneyness slope only;
  tenor-dependence not modelled (methodology §8).

### Gate

1311 passed / 2 xfailed · mypy clean · ruff clean · pylint 10.00/10. Consistency
confirmed at `skew=0.10`: gauge == roll == summary == scenario-table at the policy
depth.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
