### PR TITLE
M1.7 — unify the crash-shock skew across book and candidate surfaces

### DIFF
--- a/config/ips.yaml
+++ b/config/ips.yaml
@@ -26,9 +26,11 @@ convexity:
   target_min_pct: 15.0
   target_max_pct: 25.0
   crash_vol_shock: 0.15         # flat additive vol bump at the crash spot (M1.2)
-  skew_steepening: 0.10         # extra vol at the deep-OTM tail over ATM, linear
-                                # in log-moneyness (M1.6; methodology §2). 0.0
-                                # keeps the flat bump.
+  skew_steepening: 0.10         # extra vol reached at each leg's own ~10-delta
+                                # wing, capped there and interpolated below it
+                                # (M1.7; methodology §2). 0.0 keeps the flat bump.
+  skew_reference_delta: 0.10    # put-delta magnitude of that wing (the anchor the
+                                # steepening is calibrated to). Range (0, 0.5).
   crash_floor_reported: true    # surface the intrinsic-floor column
 
 drawdown:

--- a/deltadewa/analysis/candidate.py
+++ b/deltadewa/analysis/candidate.py
@@ -136,6 +136,8 @@ def evaluate_candidate(
     maturity_years: float,
     crash_pct: float,
     crash_vol_shock: float,
+    skew_steepening: float,
+    skew_reference_delta: float,
     vol: float | None = None,
 ) -> CandidateMetrics:
     """Price one candidate put and return per-contract economics.
@@ -149,6 +151,12 @@ def evaluate_candidate(
     :func:`~deltadewa.analysis.crash_repricing.crash_intrinsic_floor` helpers —
     no repricing logic is duplicated here.
 
+    The crash payoff carries the **same per-leg skew** the book surfaces use
+    (M1.7): the candidate's steepening is anchored to *its own*
+    ``skew_reference_delta`` wing, so evaluating a candidate at a strike the
+    book already holds yields the held leg's per-contract crash value exactly —
+    book and workbench cannot disagree at equal depth.
+
     Args:
         portfolio: Live portfolio supplying spot, vol, rate, div, exercise
             style, and valuation date.
@@ -161,6 +169,16 @@ def evaluate_candidate(
             from ``IpsConvexity.crash_vol_shock``.  Applied to the candidate's
             own vol when repricing at the crash spot, so every panel shares one
             crash basis (required — no silent divergence).
+        skew_steepening: Deep-OTM skew steepening added on top of
+            *crash_vol_shock*, capped at the candidate's own
+            ``skew_reference_delta`` wing (M1.7), from
+            ``IpsConvexity.skew_steepening``.  **Required** — no defaulted
+            ``0.0`` so the candidate can never silently revert to the flat bump
+            the book surfaces have moved off. ``0.0`` keeps the flat bump.
+        skew_reference_delta: Put-delta magnitude of the wing the steepening is
+            anchored to (e.g. ``0.10``), from
+            ``IpsConvexity.skew_reference_delta``.
+            **Required.**  Only used when *skew_steepening* is non-zero.
         vol: Implied volatility override (annualised fraction).  Defaults to
             ``portfolio.volatility`` when ``None``.
 
@@ -200,6 +218,8 @@ def evaluate_candidate(
         portfolio,
         crash_move=crash_move,
         vol_shock=crash_vol_shock,
+        skew_steepening=skew_steepening,
+        skew_reference_delta=skew_reference_delta,
         positions=[candidate_leg],
     )
     per_contract_intrinsic_floor = crash_intrinsic_floor(

--- a/deltadewa/analysis/crash_repricing.py
+++ b/deltadewa/analysis/crash_repricing.py
@@ -3,15 +3,18 @@
 Single source of the crash basis for every panel: the health convexity gauge
 (:meth:`HealthMixin.calculate_crash_convexity_pct`), the ``crash_payoff``
 payoff ratios, and the ``NetHedgeSummary`` crash-convexity ladder all reprice
-the option legs *hedge-only* at the crash spot plus a flat additive vol shock
+the option legs *hedge-only* at the crash spot plus a per-leg additive vol shock
 through these helpers, so every surface shares one basis (fixes C1/C4/Mo1).
 
 The crash state (§2):
 
 * crash spot ``S_crash = S0 * (1 + crash_move)`` — ``crash_move`` is a signed
   decimal (e.g. ``-0.25`` for a 25% decline);
-* per-leg vol ``sigma_i + vol_shock`` — ``vol_shock`` is a flat additive decimal
-  (e.g. ``+0.15``), sourced from ``IpsConvexity.crash_vol_shock``;
+* per-leg vol ``sigma_i + vol_shock + steepening_i`` — ``vol_shock`` is a flat
+  additive decimal (e.g. ``+0.15``) from ``IpsConvexity.crash_vol_shock`` on
+  every leg, and ``steepening_i`` is the deep-OTM skew add-on for that leg,
+  capped at ``IpsConvexity.skew_steepening`` at the leg's own ~10-delta wing
+  (M1.7; ``0.0`` keeps the flat bump);
 * rates, dividends, and time-to-maturity held at today's values — the crash is
   an instantaneous jump at the current valuation date;
 * the underlying / equity leg is **excluded** — convexity is a hedge-only
@@ -24,17 +27,28 @@ analytic Black-Scholes engine); no new pricer is introduced.
 
 from __future__ import annotations
 
+import functools
 import math
 from typing import TYPE_CHECKING
 
-from deltadewa.constants import OptionType
+from scipy.optimize import brentq
+
+from deltadewa.constants import ExerciseStyle, OptionType
+from deltadewa.ips_config import _DEFAULT_SKEW_REFERENCE_DELTA
 from deltadewa.valuation import OptionValuation
 
 if TYPE_CHECKING:
     from collections.abc import Sequence
+    from datetime import datetime
 
     from deltadewa.portfolio.core import OptionPortfolio
     from deltadewa.portfolio.position import OptionPosition
+
+# Bracket for the wing-strike root solve: from deep OTM (put-delta magnitude
+# ~0) up to just below ATM (magnitude ~0.5). The ~10-delta wing sits well
+# inside this range at every supported tenor.
+_WING_STRIKE_LO_FRAC = 0.05
+_WING_STRIKE_HI_FRAC = 0.9999
 
 
 def _reprice_leg(
@@ -74,94 +88,133 @@ def _reprice_leg(
     return option.price() * position.quantity * position.contract_size
 
 
-def _tail_log_moneyness(
-    legs: Sequence[OptionPosition],
+@functools.cache
+def _solve_wing_strike(
+    *,
     spot: float,
+    maturity_date: datetime,
+    volatility: float,
+    risk_free_rate: float,
+    dividend_yield: float,
+    valuation_date: datetime,
+    anchor_delta: float,
 ) -> float:
-    """Log-moneyness ``ln(S / K_tail)`` of the deepest OTM put among *legs*.
+    """Strike whose European put-delta magnitude equals *anchor_delta*.
 
-    ``K_tail`` is the lowest strike held as an out-of-the-money put
-    (``option_type == PUT`` and ``strike < spot``) — the tail anchor where the
-    skew weight reaches 1. Returns ``0.0`` when no OTM put is present, which
-    disables the steepening (there is no put wing to anchor).
+    The per-leg skew anchor: the ~10-delta wing computed at *this leg's* own
+    tenor and today-vol — a market-skew reference independent of what else the
+    book holds. Solved with :func:`scipy.optimize.brentq` on
+    ``[spot * 0.05, spot * 0.9999]``; the put-delta magnitude rises
+    monotonically from ~0 (deep OTM) to ~0.5 (ATM), so the anchor is bracketed
+    for any ``0 < anchor_delta < 0.5``.
+
+    Memoised: the wing depends only on today's state, never on ``crash_move``,
+    so a whole shock grid solves each leg's wing once.
 
     Args:
-        legs: Option legs being repriced.
-        spot: Today's underlying spot the moneyness is measured against.
+        spot: Today's underlying spot.
+        maturity_date: The leg's expiry.
+        volatility: The leg's today implied vol.
+        risk_free_rate: Portfolio risk-free rate.
+        dividend_yield: Portfolio dividend yield.
+        valuation_date: Portfolio valuation date.
+        anchor_delta: Target put-delta magnitude (e.g. ``0.10``).
 
     Returns:
-        ``ln(spot / K_tail)`` (positive), or ``0.0`` when there is no OTM put.
+        The wing strike ``K_ref`` (below spot).
+
+    Raises:
+        ValueError: When *anchor_delta* is not bracketed on the search
+            interval — the wing is unsolvable, so the skew must not silently
+            fall back to a flat bump.
 
     """
-    otm_put_strikes = [
-        position.option.strike_price
-        for position in legs
-        if position.option.option_type == OptionType.PUT
-        and position.option.strike_price < spot
-    ]
-    if not otm_put_strikes:
-        return 0.0
-    return math.log(spot / min(otm_put_strikes))
 
+    def _abs_put_delta_gap(strike: float) -> float:
+        put = OptionValuation(
+            spot_price=spot,
+            strike_price=strike,
+            maturity_date=maturity_date,
+            volatility=volatility,
+            risk_free_rate=risk_free_rate,
+            dividend_yield=dividend_yield,
+            option_type=OptionType.PUT,
+            valuation_date=valuation_date,
+            exercise_style=ExerciseStyle.EUROPEAN,
+        )
+        return abs(put.delta()) - anchor_delta
 
-def _skew_weight(
-    position: OptionPosition,
-    spot: float,
-    tail_log_moneyness: float,
-) -> float:
-    """Log-moneyness interpolation weight ``w`` in ``[0, 1]`` for one leg.
-
-    ``0`` at ATM and for calls / ITM puts (no wing steepening), ``1`` at the
-    deepest OTM put (the tail anchor), linear in ``ln(S / K)`` between. The
-    leg's extra crash vol is ``skew_steepening * w``.
-
-    Args:
-        position: Option leg to weight.
-        spot: Today's underlying spot the moneyness is measured against.
-        tail_log_moneyness: ``ln(S / K_tail)`` from :func:`_tail_log_moneyness`.
-
-    Returns:
-        The interpolation weight in ``[0, 1]``.
-
-    """
-    if tail_log_moneyness <= 0.0:
-        return 0.0
-    if position.option.option_type != OptionType.PUT:
-        return 0.0
-    strike = position.option.strike_price
-    if strike >= spot:
-        return 0.0
-    return min(1.0, math.log(spot / strike) / tail_log_moneyness)
+    lo = spot * _WING_STRIKE_LO_FRAC
+    hi = spot * _WING_STRIKE_HI_FRAC
+    if _abs_put_delta_gap(lo) >= 0.0 or _abs_put_delta_gap(hi) <= 0.0:
+        raise ValueError(
+            f"crash skew anchor delta {anchor_delta} is not bracketed on "
+            f"[{lo:.2f}, {hi:.2f}] at this tenor/vol; cannot solve the wing",
+        )
+    return float(brentq(_abs_put_delta_gap, lo, hi, xtol=0.01, maxiter=100))
 
 
 def _leg_crash_vol(
     position: OptionPosition,
+    *,
+    spot: float,
+    risk_free_rate: float,
+    dividend_yield: float,
+    valuation_date: datetime,
     vol_shock: float,
     skew_steepening: float,
-    spot: float,
-    tail_log_moneyness: float,
+    skew_reference_delta: float,
 ) -> float:
-    """Shocked crash vol for one leg: flat bump plus deep-OTM steepening.
+    """Shocked crash vol for one leg: flat bump plus a capped wing steepening.
+
+    ``sigma_i + vol_shock`` for calls and ATM/ITM puts. For an OTM put the crash
+    vol adds ``min(skew_steepening, slope * ln(S/K))`` where
+    ``slope = skew_steepening / ln(S / K_ref)`` and ``K_ref`` is the leg's own
+    ~``skew_reference_delta`` wing (:func:`_solve_wing_strike`). The extra vol
+    is thus ``skew_steepening`` exactly at the wing and interpolates linearly
+    (in log-moneyness) below it — never extrapolated past the calibrated wing
+    (the cap). The anchor is per-leg, so a leg's crash vol never depends on what
+    else the book holds.
 
     When ``skew_steepening`` is ``0.0`` this returns exactly
-    ``position.option.volatility + vol_shock`` — the original flat-bump
-    expression — so the disabled knob reproduces every prior value bit-for-bit.
+    ``position.option.volatility + vol_shock`` — the flat-bump expression — and
+    solves no wing, so the disabled knob reproduces every prior value
+    bit-for-bit.
 
     Args:
         position: Option leg to shock.
-        vol_shock: Flat additive vol bump applied to every leg.
-        skew_steepening: Extra vol added at the deep-OTM tail (``0.0`` = off).
         spot: Today's underlying spot the moneyness is measured against.
-        tail_log_moneyness: ``ln(S / K_tail)`` from :func:`_tail_log_moneyness`.
+        risk_free_rate: Portfolio risk-free rate (for the wing solve).
+        dividend_yield: Portfolio dividend yield (for the wing solve).
+        valuation_date: Portfolio valuation date (for the wing solve).
+        vol_shock: Flat additive vol bump applied to every leg.
+        skew_steepening: Extra vol added at the leg's own wing (``0.0`` = off).
+        skew_reference_delta: Put-delta magnitude of that wing (e.g. ``0.10``).
 
     Returns:
         The leg's shocked volatility as a decimal.
 
     """
+    base = position.option.volatility + vol_shock
     if skew_steepening == 0.0:
-        return position.option.volatility + vol_shock
-    weight = _skew_weight(position, spot, tail_log_moneyness)
-    return position.option.volatility + vol_shock + skew_steepening * weight
+        return base
+    if position.option.option_type != OptionType.PUT:
+        return base
+    strike = position.option.strike_price
+    if strike >= spot:
+        return base
+    k_ref = _solve_wing_strike(
+        spot=spot,
+        maturity_date=position.option.maturity_date,
+        volatility=position.option.volatility,
+        risk_free_rate=risk_free_rate,
+        dividend_yield=dividend_yield,
+        valuation_date=valuation_date,
+        anchor_delta=skew_reference_delta,
+    )
+    slope = skew_steepening / math.log(spot / k_ref)
+    extra = min(skew_steepening, slope * math.log(spot / strike))
+    return base + extra
 
 
 def crash_hedge_value(
@@ -170,6 +223,7 @@ def crash_hedge_value(
     crash_move: float,
     vol_shock: float,
     skew_steepening: float = 0.0,
+    skew_reference_delta: float = _DEFAULT_SKEW_REFERENCE_DELTA,
     positions: Sequence[OptionPosition] | None = None,
 ) -> float:
     """Hedge-only value of the option legs repriced at the crash state (§2-3).
@@ -184,9 +238,14 @@ def crash_hedge_value(
         vol_shock: Flat additive vol bump as a decimal (e.g. ``+0.15``) applied
             to every leg's own today-vol.
         skew_steepening: Optional extra vol added at the deep-OTM tail on top of
-            ``vol_shock``, interpolated linearly in log-moneyness from ``0`` at
-            ATM to the full value at the deepest OTM put (M1.6). ``0.0`` (the
-            default) keeps the flat bump and reproduces prior values exactly.
+            ``vol_shock``, capped at this value at each leg's own
+            ``skew_reference_delta`` wing and interpolated (in log-moneyness)
+            below it (M1.7). ``0.0`` (the default) keeps the flat bump and
+            reproduces prior values exactly.
+        skew_reference_delta: Put-delta magnitude of the wing the steepening is
+            anchored to (e.g. ``0.10``), sourced from
+            ``IpsConvexity.skew_reference_delta``. Only consulted when
+            ``skew_steepening`` is non-zero.
         positions: Legs to price. Defaults to every position in the portfolio;
             pass a subset (e.g. the long puts) to value part of the book.
 
@@ -196,11 +255,6 @@ def crash_hedge_value(
     """
     legs = portfolio.positions if positions is None else positions
     crash_spot = portfolio.spot_price * (1.0 + crash_move)
-    tail_log_moneyness = (
-        _tail_log_moneyness(legs, portfolio.spot_price)
-        if skew_steepening != 0.0
-        else 0.0
-    )
     return float(
         sum(
             _reprice_leg(
@@ -209,10 +263,13 @@ def crash_hedge_value(
                 crash_spot,
                 _leg_crash_vol(
                     position,
-                    vol_shock,
-                    skew_steepening,
-                    portfolio.spot_price,
-                    tail_log_moneyness,
+                    spot=portfolio.spot_price,
+                    risk_free_rate=portfolio.risk_free_rate,
+                    dividend_yield=portfolio.dividend_yield,
+                    valuation_date=portfolio.valuation_date,
+                    vol_shock=vol_shock,
+                    skew_steepening=skew_steepening,
+                    skew_reference_delta=skew_reference_delta,
                 ),
             )
             for position in legs
@@ -252,6 +309,7 @@ def crash_convexity_pct(
     crash_move: float,
     vol_shock: float,
     skew_steepening: float = 0.0,
+    skew_reference_delta: float = _DEFAULT_SKEW_REFERENCE_DELTA,
 ) -> float:
     """Crash convexity: hedge-only value change as % of the protected book (§1).
 
@@ -265,9 +323,13 @@ def crash_convexity_pct(
         crash_move: Signed crash move as a decimal (e.g. ``-0.25``).
         vol_shock: Flat additive vol bump as a decimal (e.g. ``+0.15``).
         skew_steepening: Optional deep-OTM skew steepening applied to the crash
-            leg only (M1.6). ``0.0`` (the default) keeps the flat bump. The
-            today-value ``V_today`` is always skew-free — steepening is a
-            crash-state effect.
+            leg only, capped at each leg's own ``skew_reference_delta`` wing
+            (M1.7). ``0.0`` (the default) keeps the flat bump. The today-value
+            ``V_today`` is always skew-free — steepening is a crash-state
+            effect.
+        skew_reference_delta: Put-delta magnitude of the wing the steepening is
+            anchored to (e.g. ``0.10``). Only consulted when ``skew_steepening``
+            is non-zero.
 
     Returns:
         Crash convexity as a percentage of the protected book. ``0.0`` when the
@@ -283,6 +345,7 @@ def crash_convexity_pct(
         crash_move=crash_move,
         vol_shock=vol_shock,
         skew_steepening=skew_steepening,
+        skew_reference_delta=skew_reference_delta,
     )
     return (v_crash - v_today) / book * 100.0
 

--- a/deltadewa/analysis/health.py
+++ b/deltadewa/analysis/health.py
@@ -197,7 +197,7 @@ class HealthMixin:
         self,
         crash_scenario_pct: float,
         crash_vol_shock: float,
-        skew_steepening: float = 0.0,
+        skew_steepening: float,
     ) -> float:
         """Calculate crash convexity, hedge-only and repriced (§1-3).
 
@@ -221,12 +221,13 @@ class HealthMixin:
                 caller (the gauge, the scenario table, and the roll trigger) so
                 no site can silently reprice at a different vol. Pass ``0.0``
                 explicitly for a spot-only crash when no IPS shock applies.
-            skew_steepening: Optional extra vol added at the deep-OTM tail on
-                top of ``crash_vol_shock``, interpolated linearly in
-                log-moneyness from ``0`` at ATM to the full value at the deepest
-                OTM put (M1.6). Single-sourced from
-                ``IpsConvexity.skew_steepening``; ``0.0`` (the default) keeps
-                the flat bump.
+            skew_steepening: Extra vol added at the deep-OTM tail on top of
+                ``crash_vol_shock``, capped at each leg's own ~10-delta wing and
+                interpolated (in log-moneyness) below it (M1.7). **Required** —
+                single-sourced from ``IpsConvexity.skew_steepening`` by every
+                caller (the gauge, the scenario table, and the roll trigger) so
+                no site can silently reprice a flat bump by omission. Pass
+                ``0.0`` explicitly for a flat bump when no skew applies.
 
         Returns:
             Hedge-only crash convexity as a percentage of the protected book

--- a/deltadewa/analysis/sizing.py
+++ b/deltadewa/analysis/sizing.py
@@ -266,6 +266,12 @@ def size_hedge(
     pricing to :func:`~deltadewa.analysis.candidate.evaluate_candidate`, then
     calls :func:`size_from_unit` for the scalar arithmetic.
 
+    The per-contract payoff is priced with the **same crash skew** the book
+    surfaces use — ``crash_vol_shock`` plus the per-leg ``skew_steepening``
+    anchored to each candidate's own ``skew_reference_delta`` wing, all sourced
+    from ``ips_config.convexity`` (M1.7). Sizing therefore no longer
+    under-states payoffs on the flat bump and over-hedges relative to the gauge.
+
     Sizing operates on the **beta-adjusted (SPX-equivalent) notional**
     ``book_notional * ips_config.sizing.portfolio_beta`` (handbook §2499): the
     crash offset and achieved convexity are measured against it, so a book beta
@@ -320,6 +326,8 @@ def size_hedge(
         maturity_years=candidate_maturity_years,
         crash_pct=crash_pct,
         crash_vol_shock=ips_config.convexity.crash_vol_shock,
+        skew_steepening=ips_config.convexity.skew_steepening,
+        skew_reference_delta=ips_config.convexity.skew_reference_delta,
         vol=vol,
     )
 

--- a/deltadewa/analysis/strike_ladder.py
+++ b/deltadewa/analysis/strike_ladder.py
@@ -331,6 +331,8 @@ def build_strike_ladder(
             maturity_years=maturity,
             crash_pct=crash_pct,
             crash_vol_shock=conv.crash_vol_shock,
+            skew_steepening=conv.skew_steepening,
+            skew_reference_delta=conv.skew_reference_delta,
             vol=vol,
         )
         sizing = size_from_unit(

--- a/deltadewa/ips_config.py
+++ b/deltadewa/ips_config.py
@@ -18,10 +18,12 @@ from deltadewa.constants import ExerciseStyle
 # Defaults for the crash-repricing knobs that live alongside
 # ``crash_scenario_pct`` in the ``convexity`` section. The crash *move* itself
 # is single-sourced from ``crash_scenario_pct`` (never duplicated here); these
-# knobs are the flat vol-bump magnitude, the deep-OTM skew steepening (M1.6),
-# and the intrinsic-floor toggle used by the M1.2 crash-repricing metric.
+# knobs are the flat vol-bump magnitude, the deep-OTM skew steepening and the
+# put-delta wing it is anchored to (M1.6/M1.7), and the intrinsic-floor toggle
+# used by the M1.2 crash-repricing metric.
 _DEFAULT_CRASH_VOL_SHOCK: Final[float] = 0.15
 _DEFAULT_SKEW_STEEPENING: Final[float] = 0.0
+_DEFAULT_SKEW_REFERENCE_DELTA: Final[float] = 0.10
 _DEFAULT_CRASH_FLOOR_REPORTED: Final[bool] = True
 
 # Default for the delta-drift target that lives alongside the delta_drift
@@ -127,11 +129,14 @@ class IpsConvexity:
 
     ``crash_scenario_pct`` is the single source of truth for the crash *move*
     (a signed percent, e.g. ``-25.0``) across every panel. ``crash_vol_shock``,
-    ``skew_steepening`` and ``crash_floor_reported`` are the crash-repricing
-    knobs co-located here (see ``docs/repricing-methodology.md`` §5): the flat
-    additive volatility bump applied at the crash spot, an optional deep-OTM
-    skew steepening added on top of that bump at the tail (M1.6; ``0.0`` keeps
-    the flat bump), and whether the intrinsic-floor column is surfaced.
+    ``skew_steepening``, ``skew_reference_delta`` and ``crash_floor_reported``
+    are the crash-repricing knobs co-located here (see
+    ``docs/repricing-methodology.md`` §5): the flat additive volatility bump
+    applied at the crash spot, an optional deep-OTM skew steepening added on top
+    of that bump and capped at each leg's own ~10-delta wing (M1.6/M1.7; ``0.0``
+    keeps the flat bump), the put-delta magnitude of that wing (the anchor the
+    steepening is calibrated to, e.g. ``0.10``), and whether the intrinsic-floor
+    column is surfaced.
     """
 
     crash_scenario_pct: float
@@ -139,6 +144,7 @@ class IpsConvexity:
     target_max_pct: float
     crash_vol_shock: float = _DEFAULT_CRASH_VOL_SHOCK
     skew_steepening: float = _DEFAULT_SKEW_STEEPENING
+    skew_reference_delta: float = _DEFAULT_SKEW_REFERENCE_DELTA
     crash_floor_reported: bool = _DEFAULT_CRASH_FLOOR_REPORTED
 
 
@@ -323,6 +329,15 @@ def _parse_convexity(config: dict[str, Any]) -> IpsConvexity:
         _DEFAULT_SKEW_STEEPENING,
     )
     _require_non_negative(skew_steepening, "convexity.skew_steepening")
+    skew_reference_delta = section.get(
+        "skew_reference_delta",
+        _DEFAULT_SKEW_REFERENCE_DELTA,
+    )
+    if not 0 < skew_reference_delta < 0.5:
+        raise IpsConfigError(
+            "convexity.skew_reference_delta must be in (0, 0.5), got "
+            f"{skew_reference_delta}",
+        )
     crash_floor_reported = bool(
         section.get("crash_floor_reported", _DEFAULT_CRASH_FLOOR_REPORTED),
     )
@@ -333,6 +348,7 @@ def _parse_convexity(config: dict[str, Any]) -> IpsConvexity:
         target_max_pct=target_max_pct,
         crash_vol_shock=crash_vol_shock,
         skew_steepening=skew_steepening,
+        skew_reference_delta=skew_reference_delta,
         crash_floor_reported=crash_floor_reported,
     )
 

--- a/docs/implementation-plan.md
+++ b/docs/implementation-plan.md
@@ -344,10 +344,13 @@ the honest calibration and the re-size decision recorded either way.
 
 ### M1.7 — Unify the crash-shock skew across book and candidate surfaces
 
-**Status: DONE** (per-leg re-anchor + candidate wiring). Promoted from M1.6's
-deferred sub-bullet because it is a cross-surface inconsistency with a directional
-bias, not a cosmetic gap — and closed before M2.3 surfaces the sizing workbench in
-Dash, so book and workbench cannot disagree in front of a user.
+**Status: DONE (closed 2026-07-25).** Per-leg re-anchor, candidate wiring,
+methodology re-golden, and the regression guards all landed; the full gate is green
+and every acceptance number was re-confirmed from the engine at close-out (table
+below). Promoted from M1.6's deferred sub-bullet because it is a cross-surface
+inconsistency with a directional bias, not a cosmetic gap — and closed before M2.3
+surfaces the sizing workbench in Dash, so book and workbench cannot disagree in
+front of a user.
 
 **Resolution.** Landed in two commits, full gate green after each:
 
@@ -400,6 +403,66 @@ Dash, so book and workbench cannot disagree in front of a user.
   `skew_steepening` is now required (no default) on the health gauge, mirroring
   `crash_vol_shock` (M1.4/M1.5), with source guards confirming the roll trigger and
   scenario table source it from the IPS.
+
+**M1.7 CLOSE-OUT (DONE, 2026-07-25).** Full gate green (pytest 1332 passed /
+2 xfailed, mypy clean, ruff check + format clean, pylint 10.00/10) and every
+acceptance number re-confirmed from the engine at close-out:
+
+| Property | Confirmed |
+| --- | --- |
+| §4 book convexity | **+24.64%** (V_crash ≈ $5.23M, 17.5×) — rides 0.36pp under the +25% ceiling |
+| Canonical convexity | **+16.10%** (valuation 2026-07-25; ≈+16.1%) — in-band, +1.10pp over the +15% floor, not re-sized |
+| Book == candidate at equal depth | per-contract crash payoff identical (K5280: $109,754.31 on both paths) |
+| Composition invariance | a held leg's crash vol is byte-identical after adding a deeper put |
+| `skew = 0` no-op | V_crash byte-identical to the parameter-omitted call |
+| No silent skew default | no production crash path reprices flat by omission (below) |
+
+**Decisions (recorded against the measured numbers, not preference).**
+
+- **D3 — faithful ~10-delta wing anchor, not a %OTM proxy.** The steepening anchors
+  to each leg's own ~10-delta wing, solved per leg (`_solve_wing_strike`). A
+  fixed-%OTM proxy only preserved §4's band because §4's tail happens to sit at
+  40% OTM — a property of *that book*, not of the calibration; on a book whose tail
+  sits elsewhere the proxy misplaces the anchor. The delta wing is a market-faithful
+  reference that holds for any book.
+- **D5 — cap the steepening at the wing, never extrapolate.** No skew calibration
+  exists beyond the ~10-delta wing, so extrapolating the slope past it would
+  fabricate deep-tail IV; holding it flat under-states it (the conservative direction
+  for a tail program). Measured: capping returns §4 from the **uncapped +27.71%**
+  (out of band, over the +25% ceiling) to the **in-band +24.64%** — the cap is what
+  keeps a faithful anchor in-band.
+- **D4 — no canonical re-size.** The canonical reads **+16.10%** under the honest
+  per-leg model — **cap-invariant** (its legs are shallower than their own wings, so
+  the cap never binds: capped == uncapped == +16.10%), **+1.10pp over the +15%
+  floor**. That in-band reading is a property of the honest model, not of M1.6's
+  book-relative artifact (which inflated the shallow leg's steepening by tracking the
+  *deepest held* put). In-band on the honest number ⇒ no re-size.
+- **§4 re-goldened in place at +24.64%**, riding **0.36pp under the +25% ceiling by
+  design** (a deliberately deep 20/30/40 ladder), pinned by **value, not the
+  `meets_target` boolean** (the Prompt E guard), so any re-calibration surfaces as a
+  visible number change rather than a silent flip.
+
+**Resolved.** The **book/candidate split** is closed (a candidate at a held strike
+reproduces that leg's per-contract crash value exactly) and **composition-dependence**
+is closed (per-leg anchor). The **≈23% sizing over-hedge bias** is gone: M1.6's
+flat-bump candidate under-stated the tail payoff, so sizing bought ≈23% more carry
+than the skew gauge implied; the candidate now carries the same per-leg skew, so the
+bias is eliminated.
+
+**No silent skew default.** The shipped `config/ips.yaml` sets `skew_steepening:
+0.10` explicitly (it does not inherit the `0.0` policy default); the health gauge and
+`evaluate_candidate` **require** the skew (no default); and every book surface (roll
+trigger, health metrics, scenario table, crash-payoff display) **sources** it from
+the IPS — guarded by `test_skew_steepening_is_required_on_the_gauge` and the roll /
+table source guards. The `= 0.0` defaults that remain are deliberate no-op ergonomics
+no crash path relies on: the today-value primitive (`hedge_value`, skew-free by
+definition), the payoff entry points (all production callers pass skew), and the
+`NetHedgeSummary` widget + the `IpsConvexity` dataclass — the same posture
+`crash_vol_shock` carries.
+
+**Remaining deferral.** The shock's **term structure** — one cross-sectional slope;
+each leg's wing is already solved at its own tenor, so what remains is how the slope
+itself varies *across* tenors (methodology §8).
 
 **The problem, one root.** M1.6 anchors the skew weight to the book's deepest held
 put (`_tail_log_moneyness` = `ln(S / min(otm_put_strikes))`). Two consequences:

--- a/docs/implementation-plan.md
+++ b/docs/implementation-plan.md
@@ -375,8 +375,16 @@ Dash, so book and workbench cannot disagree in front of a user.
   (methodology §8).
 - **Notebook crash-panel wiring** — `NetHedgeSummary`'s skew param and
   `compute_crash_convexity`'s shock argument (Dash-migration scope).
-- **Methodology doc re-golden** — `docs/repricing-methodology.md` §2/§4/§7/§8 still
-  carry M1.6 framing; recompute alongside the Dash cut.
+
+**Resolved since (auditable close-out):**
+
+- **Methodology doc re-golden — RESOLVED** (`feat(crash): re-golden §4 …`).
+  `docs/repricing-methodology.md` §2/§4/§5/§7/§8 rewritten under the capped
+  per-leg ~10-delta anchor — the numbers `b1f4e3d` moved (the split the policy
+  forbids, now closed in one commit): §4 = **+24.64% / 17.5× / $5.23M** (V_today
+  and the intrinsic floor unchanged); canonical **asserted in-band at ~+16.1%**
+  and not re-sized; §8 marks composition-dependence and the book/candidate split
+  resolved, leaving the shock's term structure as the remaining simplification.
 
 **The problem, one root.** M1.6 anchors the skew weight to the book's deepest held
 put (`_tail_log_moneyness` = `ln(S / min(otm_put_strikes))`). Two consequences:

--- a/docs/implementation-plan.md
+++ b/docs/implementation-plan.md
@@ -370,7 +370,9 @@ Dash, so book and workbench cannot disagree in front of a user.
   `crash_hedge_value`'s 0.10 default for the anchor — **no observable difference at
   the shipped 0.10 default**. Threading it as a third scalar is pylint-arity-blocked
   (`_build_scenario_rows` is already at `max-args = 8`); the value-object bundle
-  that would unblock it was declined, so this waits on that refactor.
+  that would unblock it was declined, so this waits on that refactor. (Untouched by
+  the Prompt E fail-loud guard: the anchor's default is `0.10`, a wing — not a
+  defaulted `0.0` — so it is out of that guard's scope.)
 - **Crash-shock term structure** — one cross-sectional slope, no tenor dependence
   (methodology §8).
 - **Notebook crash-panel wiring** — `NetHedgeSummary`'s skew param and
@@ -385,6 +387,19 @@ Dash, so book and workbench cannot disagree in front of a user.
   and the intrinsic floor unchanged); canonical **asserted in-band at ~+16.1%**
   and not re-sized; §8 marks composition-dependence and the book/candidate split
   resolved, leaving the shock's term structure as the remaining simplification.
+- **Structural regression guards — RESOLVED**
+  (`test(crash): guard skew consistency, composition invariance, and ceiling
+  proximity`). Five load-bearing M1.7 properties are now pinned so a future
+  re-calibration can't silently break them: (1) §4 anchored on the **convexity
+  value** (+24.64%, riding 0.36pp under the +25% ceiling by design), not the
+  `meets_target` boolean; (2) health gauge == roll trigger == summary ladder ==
+  crash_payoff scenario table at equal depth under the skew-aware shock; (3)
+  **composition invariance** as a first-class byte-for-byte test (no leg's crash
+  vol depends on what else the book holds); (4) **no-op** — `skew_steepening=0.0`
+  reproduces the flat baseline byte-for-byte at the primitive; (5) **fail-loud** —
+  `skew_steepening` is now required (no default) on the health gauge, mirroring
+  `crash_vol_shock` (M1.4/M1.5), with source guards confirming the roll trigger and
+  scenario table source it from the IPS.
 
 **The problem, one root.** M1.6 anchors the skew weight to the book's deepest held
 put (`_tail_log_moneyness` = `ln(S / min(otm_put_strikes))`). Two consequences:

--- a/docs/implementation-plan.md
+++ b/docs/implementation-plan.md
@@ -344,10 +344,39 @@ the honest calibration and the re-size decision recorded either way.
 
 ### M1.7 — Unify the crash-shock skew across book and candidate surfaces
 
-**Status: open (follow-up from M1.6).** Promoted from M1.6's deferred sub-bullet
-because it is a cross-surface inconsistency with a directional bias, not a cosmetic
-gap. Sequence **before M2.3 surfaces the sizing workbench** in Dash (or before the
-next release), so book and workbench cannot disagree in front of a user.
+**Status: DONE** (per-leg re-anchor + candidate wiring). Promoted from M1.6's
+deferred sub-bullet because it is a cross-surface inconsistency with a directional
+bias, not a cosmetic gap — and closed before M2.3 surfaces the sizing workbench in
+Dash, so book and workbench cannot disagree in front of a user.
+
+**Resolution.** Landed in two commits, full gate green after each:
+
+- **`b1f4e3d` — per-leg wing re-anchor.** `_leg_crash_vol` anchors each leg's
+  steepening to its own ~10-delta wing (`skew_reference_delta`, IPS-configurable,
+  default 0.10), capped there; `_tail_log_moneyness` / `_skew_weight` deleted. The
+  function takes no book context, so a leg's crash vol is composition-independent.
+  §4 re-goldened in place at **+24.64%** (17.5×, `V_crash` ≈ $5.23M); canonical
+  **+16.11%**, neither re-sized; `skew = 0.0` still a byte-for-byte no-op.
+- **`fix(sizing)` — candidate wiring (this commit).** `evaluate_candidate` takes
+  the skew as **required** params; `size_hedge` and `build_strike_ladder` source
+  them from `ips_config.convexity`. The flat-bump split is gone: a candidate at a
+  held strike reproduces that leg's per-contract crash value exactly, and the
+  sizing payoff agrees with the gauge at equal depth.
+
+**Still-deferred follow-ups (tracked; not blocking M1.7 acceptance):**
+
+- **Book surfaces source `skew_reference_delta` from the IPS.** `crash_payoff` /
+  `health` / `roll_status` forward `skew_steepening` but inherit
+  `crash_hedge_value`'s 0.10 default for the anchor — **no observable difference at
+  the shipped 0.10 default**. Threading it as a third scalar is pylint-arity-blocked
+  (`_build_scenario_rows` is already at `max-args = 8`); the value-object bundle
+  that would unblock it was declined, so this waits on that refactor.
+- **Crash-shock term structure** — one cross-sectional slope, no tenor dependence
+  (methodology §8).
+- **Notebook crash-panel wiring** — `NetHedgeSummary`'s skew param and
+  `compute_crash_convexity`'s shock argument (Dash-migration scope).
+- **Methodology doc re-golden** — `docs/repricing-methodology.md` §2/§4/§7/§8 still
+  carry M1.6 framing; recompute alongside the Dash cut.
 
 **The problem, one root.** M1.6 anchors the skew weight to the book's deepest held
 put (`_tail_log_moneyness` = `ln(S / min(otm_put_strikes))`). Two consequences:
@@ -379,10 +408,11 @@ Recommendation: (A) — it fixes both consequences at one root and keeps a singl
 skew function everywhere. Confirm the calibration can be expressed as an absolute
 slope consistent with the signed-off `0.10`-at-the-tail figure before committing.
 
-**Acceptance:** one skew function drives book and candidate surfaces; a fixed leg's
-crash vol is independent of book composition; the sizing payoff ratio and the gauge
-convexity agree at equal depth on the §4 book; goldens and methodology recomputed
-together; `skew = 0` still a byte-for-byte no-op.
+**Acceptance (all met):** one skew function drives book and candidate surfaces; a
+fixed leg's crash vol is independent of book composition; the sizing payoff ratio
+and the gauge convexity agree at equal depth on the §4 book; goldens recomputed
+(methodology doc re-golden tracked as a follow-up above); `skew = 0` still a
+byte-for-byte no-op.
 
 ## Phase 2 — Dash rebuild (build on the trusted engine)
 

--- a/docs/repricing-methodology.md
+++ b/docs/repricing-methodology.md
@@ -42,26 +42,42 @@ construct the crash state:
 | Quantity | Rule | Source |
 |---|---|---|
 | Crash spot | $S_{\text{crash}} = S_0 (1 + m)$ | `ips.crash.scenario_move` (default **−0.25**) |
-| Crash vol (per leg) | $\sigma_{i,\text{crash}} = \sigma_{i,\text{today}} + \Delta\sigma + \kappa\, w_i$ | `ips.crash.vol_shock` (**+0.15**, flat ATM base) + `ips.crash.skew_steepening` (**+0.10**, deep-OTM tail) |
+| Crash vol (per leg) | $\sigma_{i,\text{crash}} = \sigma_{i,\text{today}} + \Delta\sigma + \kappa\, w_i$ | `ips.crash.vol_shock` (**+0.15**, flat ATM base) + `ips.crash.skew_steepening` (**+0.10**, deep-OTM tail) anchored at `ips.crash.skew_reference_delta` (**0.10**) |
 | Rate / dividend | held at today's values | — |
 | Time to maturity | **unchanged** ($t_0$ fixed) | — |
 | Engine | European closed form (QuantLib `AnalyticEuropeanEngine` = Black–Scholes) | README: American forbidden for SPX |
 
 **The shock is skew-aware.** Every leg gets the flat additive bump $\Delta\sigma$
 (`vol_shock`, +0.15) at its own today-vol; deep-OTM puts get an *additional*
-steepening on top, up to $\kappa$ (`skew_steepening`, +0.10) at the deepest tail:
+steepening on top, up to $\kappa$ (`skew_steepening`, +0.10) at the ~10-delta
+wing — computed **per leg**, against that leg's own wing, not the book's:
 
 $$\sigma_{i,\text{crash}} = \sigma_{i,\text{today}} + \Delta\sigma + \kappa\, w_i,
 \qquad
 w_i = \begin{cases}
-\min\!\left(1,\; \dfrac{\ln(S_0/K_i)}{\ln(S_0/K_{\text{tail}})}\right) & K_i < S_0 \text{ (OTM put)}\\[1.2em]
+\min\!\left(1,\; \dfrac{\ln(S_0/K_i)}{\ln(S_0/K_{\text{ref},i})}\right) & K_i < S_0 \text{ (OTM put)}\\[1.2em]
 0 & \text{calls, ATM/ITM puts}
 \end{cases}$$
 
-The weight $w_i$ is **linear in log-moneyness** $\ln(S_0/K_i)$, measured against
-*today's* spot: $w = 0$ at ATM (and for calls / ITM puts, which do not steepen)
-and $w = 1$ at $K_{\text{tail}}$, the deepest OTM put held. Setting $\kappa = 0$
-recovers the flat bump exactly.
+$K_{\text{ref},i}$ is **leg $i$'s own ~10-delta wing** — the strike whose European
+put-delta magnitude equals `skew_reference_delta` (0.10) at *that leg's own* tenor
+and today-vol, solved once per leg (`_solve_wing_strike`). The weight $w_i$ is
+**linear in log-moneyness** $\ln(S_0/K_i)$ against today's spot: $w = 0$ at ATM
+(and for calls / ITM puts, which do not steepen), rising to $w = 1$ at the leg's
+own wing. Because the anchor is the leg's own wing — a property of that strike and
+tenor, not of what else the book holds — **a leg's crash vol is independent of
+book composition** (M1.7). Setting $\kappa = 0$ recovers the flat bump exactly and
+solves no wing.
+
+**Capped at the wing, never extrapolated.** For a put *deeper* than its own
+~10-delta wing ($K_i < K_{\text{ref},i}$) the $\min$ binds: the steepening holds
+flat at $\kappa$ rather than continuing to grow. This is deliberate. $\kappa$ is
+calibrated to the ~10-delta wing (§5), and **no skew observation constrains the
+model past it** — the 5-delta / 2-delta region the linear slope would extrapolate
+into is not something the historical episodes pin down. Inventing vol there would
+overstate deep-tail IV; **holding it flat is the conservative direction** — capped
+steepening *under*-states deep-tail IV, so it under- rather than over-states
+protection, the safe error for a tail program.
 
 **Calibration of $\kappa$.** In a real sell-off deep-OTM index puts gain *more* IV
 than ATM — the put wing steepens. In 2008 and 2020 the ≈10-delta wing steepened by
@@ -69,14 +85,16 @@ than ATM — the put wing steepens. In 2008 and 2020 the ≈10-delta wing steepe
 **+0.10** is a deliberately conservative central estimate (plausible range
 +0.05…+0.20): understating the steepening errs toward *less* apparent protection,
 the safe direction for a tail program. It is calibrated from the historical
-episodes alone, not to any book's target band (see §5, and the M1.6 rationale in
+episodes alone, not to any book's target band (see §5, and the rationale in
 `docs/implementation-plan.md`).
 
 **`ips.crash.scenario_move`, `.vol_shock`, and `.skew_steepening` are each a single
 source of truth** across every crash panel — the health gauge, the scenario table,
-the summary ladder, and the roll-status trigger all read the same three knobs and
-the same book tail, so a crash number is identical across surfaces at equal depth.
-This removes the −20% / −25% split (**Mo1**); no panel carries its own constant.
+the summary ladder, and the roll-status trigger all read the same knobs, so a
+crash number is identical across surfaces at equal depth. This removes the
+−20% / −25% split (**Mo1**); no panel carries its own constant.
+`skew_reference_delta` — the wing the steepening anchors to — defaults to 0.10 and
+is IPS-configurable; the book surfaces consume that default today (§8).
 
 ---
 
@@ -87,9 +105,9 @@ $$V_{\text{today}} = \sum_i \text{price}\big(S_0,\,K_i,\,\sigma_i,\,r,\,q,\,T_i,
 $$V_{\text{crash}} = \sum_i \text{price}\big(S_{\text{crash}},\,K_i,\,\sigma_i+\Delta\sigma+\kappa\, w_i,\,r,\,q,\,T_i,\,\text{style}_i\big)\cdot q_i \cdot c_i$$
 
 where $q_i$ = signed contract quantity, $c_i$ = contract size, $T_i$ unchanged,
-and the per-leg skew weight $w_i$ is defined in §2 ($\kappa = 0$ gives the flat bump).
-Reprice via the **existing** `OptionValuation` / `BatchPricer` — do not add a new
-pricer.
+and the per-leg skew weight $w_i$ — anchored at each leg's own ~10-delta wing and
+capped there — is defined in §2 ($\kappa = 0$ gives the flat bump). Reprice via
+the **existing** `OptionValuation` / `BatchPricer` — do not add a new pricer.
 
 **Intrinsic floor** (reported as a separate, clearly-labelled column — *never* the
 headline number):
@@ -97,7 +115,7 @@ headline number):
 $$V_{\text{crash}}^{\text{floor}} = \sum_i \max\big(\phi_i (K_i - S_{\text{crash}}),\,0\big)\cdot q_i \cdot c_i \quad (\phi=1 \text{ for puts})$$
 
 The floor is the conservative lower bound the docstrings intended; §4 shows why it
-must not be the headline (it reads 2.5× where the repriced value is 16×).
+must not be the headline (it reads 2.5× where the repriced value is 17.5×).
 
 ---
 
@@ -109,31 +127,37 @@ weighted 35/40/25 by contract count, carry ≈ 1%.
 **Inputs:** $S_0 = 6600$, $m = -0.25 \Rightarrow S_{\text{crash}} = 4950$;
 today vol $20\%$ (flat, illustrative); $r = 4.5\%$, $q = 1.5\%$, $T = 1.5$y,
 contract size 100, European puts. Crash vol is the flat base
-$\Delta\sigma = +0.15$ (35% at ATM) **plus** the skew steepening $\kappa = +0.10$
-weighted by log-moneyness — the tail anchor is the deepest put (3960), so
-$w = \ln(6600/K)/\ln(6600/3960)$ gives crash vols **39.4% / 42.0% / 45.0%** across
-the 20/30/40%-OTM rungs.
+$\Delta\sigma = +0.15$ (35% at ATM) **plus** the per-leg skew steepening
+$\kappa = +0.10$, anchored at each leg's own ~10-delta wing. At this common tenor
+and today-vol all three rungs share the wing $K_{\text{ref}} \approx 5213$
+(≈21% OTM): the 20%-OTM rung sits just *shallower* than its wing, reaching
+$w = 0.95$ (+9.5 vol pts), while the 30% and 40% rungs sit *past* the wing and
+**cap** at $\kappa$ (+10.0 vol pts each). Crash vols are thus
+**44.5% / 45.0% / 45.0%** across the 20/30/40%-OTM rungs.
 
 | Leg | Strike | Qty | $w$ | Crash vol | Price today | Price crash | Intrinsic (crash) | Value today | Value crash |
 |---|---|---|---|---|---|---|---|---|---|
-| 20% OTM | 5280 | 23 | 0.44 | 39.4% | 95.39 | 979.62 | 330.00 | \$219,392 | \$2,253,133 |
-| 30% OTM | 4620 | 26 | 0.70 | 42.0% | 27.19 | 690.56 | 0.00 | \$70,696 | \$1,795,458 |
-| 40% OTM | 3960 | 16 | 1.00 | 45.0% | 4.77 | 462.23 | 0.00 | \$7,627 | \$739,575 |
-| **Hedge** | | | | | | | | **\$297,715** | **\$4,788,166** |
+| 20% OTM | 5280 | 23 | 0.95 | 44.5% | 95.39 | 1097.54 | 330.00 | \$219,392 | \$2,524,349 |
+| 30% OTM | 4620 | 26 | 1.00 | 45.0% | 27.19 | 754.47 | 0.00 | \$70,696 | \$1,961,615 |
+| 40% OTM | 3960 | 16 | 1.00 | 45.0% | 4.77 | 462.53 | 0.00 | \$7,627 | \$740,040 |
+| **Hedge** | | | | | | | | **\$297,715** | **\$5,226,004** |
 
 - Hedge value today **\$297,715** — 1.49% of the \$20M book, ≈ **0.99%/yr** carry
   (skew is a crash-state effect, so $V_{\text{today}}$ is unchanged from the flat
   bump).
-- Hedge value in crash **\$4,788,166** (repriced) — a **16.1×** multiple.
+- Hedge value in crash **\$5,226,004** (repriced) — a **≈17.5×** multiple.
 - Intrinsic floor **\$759,000** — only **2.5×**, and it zeroes the 30% and 40% legs.
 
-$$\text{convexity} = \frac{4{,}788{,}166 - 297{,}715}{20{,}000{,}000} = \mathbf{+22.5\%} \;\Rightarrow\; \textbf{inside the IPS +15\%…+25\% band.}$$
+$$\text{convexity} = \frac{5{,}226{,}004 - 297{,}715}{20{,}000{,}000} = \mathbf{+24.64\%} \;\Rightarrow\; \textbf{inside the IPS +15\%…+25\% band.}$$
 
-**Before/after (M1.6).** Under the pre-M1.6 *flat* $+0.15$ bump (every leg at 35%
-crash vol) this same book read $V_{\text{crash}} = \$3{,}895{,}901$, a **13.1×**
-multiple and **+18.0%** convexity. The skew-aware shock lifts the deep-OTM legs
-(where the wing genuinely steepens in a crash), adding ≈4.5 pp of convexity — the
-flat bump *understated* it. Both readings sit inside the +15%…+25% band.
+**Before/after.** Under the pre-M1.6 *flat* $+0.15$ bump (every leg at 35% crash
+vol) this same book read $V_{\text{crash}} = \$3{,}895{,}901$, a **13.1×** multiple
+and **+18.0%** convexity. M1.6's first skew shock anchored the steepening to the
+book's *deepest held* put and read **+22.5%** (16.1×); M1.7 re-anchors it **per
+leg** to each leg's own ~10-delta wing (capped there), lifting the two deep rungs
+to the full $\kappa$ and reading **+24.64%** (17.5×). All three sit inside the
++15%…+25% band — each refinement recovers convexity the flat bump *understated* on
+the low strikes.
 
 **The intrinsic bug, for contrast:** the intrinsic-only basis gives
 $(759{,}000 - 297{,}715)/20{,}000{,}000 = \mathbf{+2.3\%}$ — and the pre-M1.2 code
@@ -153,7 +177,8 @@ further netted the equity loss on top, which is how a conformant book once read 
 |---|---|---|
 | `ips.crash.scenario_move` | `-0.25` | **Single source** for every crash panel (Mo1). |
 | `ips.crash.vol_shock` | `+0.15` | Flat additive bump (ATM base). See calibration note. |
-| `ips.crash.skew_steepening` | `+0.10` | Extra vol at the deep-OTM tail over ATM, linear in log-moneyness (M1.6). `0.0` recovers the flat bump. See calibration note. |
+| `ips.crash.skew_steepening` | `+0.10` | Extra vol reached at each leg's own ~10-delta wing over ATM — capped there, interpolated (linear in log-moneyness) below it (M1.6/M1.7). `0.0` recovers the flat bump. See calibration note. |
+| `ips.crash.skew_reference_delta` | `0.10` | Put-delta magnitude of the wing the steepening anchors to — the per-leg reference at which the steepening reaches full $\kappa$ (M1.7). |
 | `ips.crash.floor_reported` | `true` | Whether to surface the intrinsic-floor column. |
 
 **Calibration note for `vol_shock`.** In 2008 and 2020, index-put implied vols
@@ -165,8 +190,10 @@ policy input, so it belongs in the IPS, not in presentation config.
 in a real crash the deep-OTM wing steepens *above* ATM. In 2008/2020 the ≈10-delta
 put wing ran **15+ vol points** over ATM at the peak; **+0.10** is a conservative
 central estimate (range +0.05…+0.20) derived from those episodes alone — never
-tuned to a book's target band (M1.6 condition 1). Understating it errs toward less
-apparent protection, the safe direction for a tail program.
+tuned to a book's target band (calibration condition 1). It is the extra vol at
+the ~10-delta wing (`skew_reference_delta`), reached per leg and **capped there**
+(§2), not at whatever the book's deepest holding happens to be. Understating it
+errs toward less apparent protection, the safe direction for a tail program.
 
 ---
 
@@ -188,38 +215,57 @@ apparent protection, the safe direction for a tail program.
 ## 7. Acceptance tests (normative)
 
 1. **Golden values** — the §4 portfolio reprices to $V_{\text{today}} = \$297{,}715$
-   and $V_{\text{crash}} = \$4{,}788{,}166$ within tolerance; convexity =
-   **+22.5% ± ε** (skew-aware shock). A separate no-op test pins the flat baseline
-   at $\kappa = 0$: **+18.0%**, $V_{\text{crash}} = \$3{,}895{,}901$.
+   and $V_{\text{crash}} = \$5{,}226{,}004$ within tolerance; convexity =
+   **+24.64% ± ε** and the repriced payoff ratio ≈ **17.53×** (skew-aware, per-leg
+   wing). A separate no-op test pins the flat baseline at $\kappa = 0$: **+18.0%**,
+   $V_{\text{crash}} = \$3{,}895{,}901$, **13.1×**.
 2. **Band** — the canonical example (`examples/portfolios/spx_protective_put.yaml`)
    yields convexity within **+15%…+25%** at −25%. Under the flat bump it read
-   **+14.27%** (just under the floor); the honestly-calibrated skew shock lifts it
-   to **+16.55%**, comfortably in-band — **so no re-size is needed** (the M1.6
-   "record the re-size decision either way" outcome).
+   **+14.25%** (just under the floor); the honestly-calibrated per-leg skew shock
+   lifts it to **≈+16.1%**, comfortably in-band — **so no re-size is needed** (the
+   "record the re-size decision either way" outcome). The book is unchanged (two
+   puts, 5200/4900, 5 contracts each).
 3. **Hedge-only invariant** — adding or removing the equity leg does **not** change
    convexity (guards against C1 regressing).
 4. **Repriced invariant** — the 30% and 40% OTM legs contribute **> 0** at −25%
    (guards against C4 regressing); the intrinsic-floor column is strictly less than
    the repriced value for any strike beyond the crash move.
-5. **Single-source** — changing `ips.crash.scenario_move`, `.vol_shock`, or
+5. **Per-leg / composition-independent** — a leg's crash vol depends only on its own
+   strike and tenor versus its own ~10-delta wing, so adding a deeper put leaves a
+   shallower leg's crash vol unchanged, and a *candidate* priced at a held strike
+   reproduces that held leg's per-contract crash value exactly (M1.7).
+6. **Single-source** — changing `ips.crash.scenario_move`, `.vol_shock`, or
    `.skew_steepening` moves the health gauge, the scenario table, the summary
    ladder, and the roll trigger together (identical at equal depth).
+   `skew_reference_delta` is not yet threaded from the IPS into those book surfaces
+   (they use its 0.10 default — §8); no observable difference at that default.
 
 ---
 
 ## 8. Known simplifications (documented, not defects)
 
-- **Skew steepening — implemented (M1.6).** The deep-OTM wing now steepens above
-  ATM via `ips.crash.skew_steepening` (§2), so the shock no longer understates
-  convexity on the lowest strikes. Two limitations remain in the model:
-  - **Single-slope, cross-sectional.** The steepening is one linear-in-log-moneyness
-    slope $\kappa$ anchored at the deepest held put; it does not model the *term*
-    structure of skew (how the slope varies with tenor) — a natural next refinement.
-  - **Book-convexity surfaces only.** The gauge, roll trigger, summary ladder, and
-    scenario table read the skew shock; the **sizing / strike-ladder / candidate**
-    path stays on the flat bump for now, because pricing a *standalone* candidate as
-    its own tail would over-apply the steepening and undersize the hedge. Wiring it
-    correctly needs a per-strike skew anchor (deferred, tracked follow-up).
+- **Skew steepening — implemented and unified (M1.6/M1.7).** The deep-OTM wing
+  steepens above ATM via `ips.crash.skew_steepening` (§2), so the shock no longer
+  understates convexity on the lowest strikes. Two earlier limitations are now
+  **resolved**:
+  - **Composition-dependence — RESOLVED (M1.7, `b1f4e3d`).** M1.6 anchored the
+    steepening to the book's *deepest held* put, so a leg's crash vol moved with
+    what else was held. The anchor is now each leg's **own ~10-delta wing** — a
+    property of the strike and tenor alone — so a leg's crash vol is independent of
+    book composition.
+  - **Book / candidate split — RESOLVED (M1.7 candidate wiring).** The sizing /
+    strike-ladder / candidate path priced standalone candidates on the *flat* bump
+    (understating their payoffs ≈23% and over-hedging); with the per-leg absolute
+    anchor a candidate steepens against its own wing exactly as a held leg does, so
+    both now price the crash on one skew function — a candidate at a held strike
+    reproduces that leg's per-contract crash value exactly.
+  What remains is the shock's **term structure**: one cross-sectional
+  linear-in-log-moneyness slope $\kappa$. The *per-leg tenor* is already captured
+  (each leg's wing is solved at its own tenor and today-vol), so the open item is
+  narrower than before — how the slope itself varies **across** tenors, not the
+  per-leg tenor — a natural next refinement. (A second tracked follow-up: the book
+  surfaces still consume `skew_reference_delta`'s 0.10 default rather than sourcing
+  it from the IPS — no observable difference at that default.)
 - **Rates / dividends held constant.** Rates typically fall in a crash; the effect
   is second-order for long puts and is out of scope for this baseline.
 - **Single instantaneous horizon.** The crash is modelled as one jump at $t_0$; the

--- a/examples/ips/ips_default.yaml
+++ b/examples/ips/ips_default.yaml
@@ -26,9 +26,11 @@ convexity:
   target_min_pct: 15.0
   target_max_pct: 25.0
   crash_vol_shock: 0.15         # flat additive vol bump at the crash spot (M1.2)
-  skew_steepening: 0.10         # extra vol at the deep-OTM tail over ATM, linear
-                                # in log-moneyness (M1.6; methodology §2). 0.0
-                                # keeps the flat bump.
+  skew_steepening: 0.10         # extra vol reached at each leg's own ~10-delta
+                                # wing, capped there and interpolated below it
+                                # (M1.7; methodology §2). 0.0 keeps the flat bump.
+  skew_reference_delta: 0.10    # put-delta magnitude of that wing (the anchor the
+                                # steepening is calibrated to). Range (0, 0.5).
   crash_floor_reported: true    # surface the intrinsic-floor column
 
 drawdown:

--- a/examples/portfolios/spx_tail_20m.yaml
+++ b/examples/portfolios/spx_tail_20m.yaml
@@ -7,12 +7,14 @@
 # an in-band book to open in the monitor for demos and smoke checks.
 #
 # Golden values (§4, skew-aware crash shock, -25% crash, T = 1.5y): flat +0.15
-# vol bump at ATM plus a +0.10 deep-OTM skew steepening linear in log-moneyness,
-# so crash vols run 39.4% / 42.0% / 45.0% across the 20/30/40%-OTM rungs (M1.6):
+# vol bump at ATM plus a +0.10 skew steepening capped at each leg's own ~10-delta
+# wing (M1.7), so crash vols run 44.5% / 45.0% / 45.0% across the 20/30/40%-OTM
+# rungs (the two deeper rungs sit at/beyond their wing, so both hit the +0.10 cap):
 #   Hedge value today   ≈ $297,715   (1.49% of $20M, ≈ 0.99%/yr carry)
-#   Hedge value in crash ≈ $4,788,166 (16.1x — repriced, full option value)
-#   Convexity           ≈ +22.5%     -> inside the IPS +15%..+25% band
-# (Under the pre-M1.6 flat +0.15 bump this book read +18.0% / 13.1x.)
+#   Hedge value in crash ≈ $5,226,004 (17.6x — repriced, full option value)
+#   Convexity           ≈ +24.6%     -> inside the IPS +15%..+25% band
+# (Under the pre-M1.6 flat +0.15 bump this book read +18.0% / 13.1x; under the
+#  M1.6 book-relative anchor, +22.5% / 16.1x.)
 #
 # Maturities are relative (maturity_days: 548 ≈ 18 months) so the book stays a
 # stable ~1.5y-tenor fixture whenever it is opened, not a decaying snapshot.

--- a/tests/test_analysis/test_candidate.py
+++ b/tests/test_analysis/test_candidate.py
@@ -20,6 +20,12 @@ from deltadewa.portfolio.core import OptionPortfolio
 # not otherwise care about its exact value.
 _CRASH_VOL_SHOCK = 0.15
 
+# Crash skew knobs (IpsConvexity defaults). Since M1.7 the candidate path is
+# priced on the same per-leg skew as the book surfaces, so evaluate_candidate
+# requires both — no silent flat-bump fallback.
+_SKEW_STEEPENING = 0.10
+_SKEW_REFERENCE_DELTA = 0.10
+
 # §4 worked-example crash state (docs/repricing-methodology.md): spot 6600,
 # 18-month European puts, 20% flat today-vol, +15% crash vol shock, -25% crash.
 _APX_SPOT = 6600.0
@@ -90,6 +96,8 @@ class TestEvaluateCandidate:
             maturity_years=0.25,
             crash_pct=-25.0,
             crash_vol_shock=_CRASH_VOL_SHOCK,
+            skew_steepening=_SKEW_STEEPENING,
+            skew_reference_delta=_SKEW_REFERENCE_DELTA,
         )
         assert isinstance(result, CandidateMetrics)
 
@@ -103,6 +111,8 @@ class TestEvaluateCandidate:
             maturity_years=0.25,
             crash_pct=-25.0,
             crash_vol_shock=_CRASH_VOL_SHOCK,
+            skew_steepening=_SKEW_STEEPENING,
+            skew_reference_delta=_SKEW_REFERENCE_DELTA,
         )
         assert result.pct_otm == pytest.approx(5.0)
 
@@ -115,6 +125,8 @@ class TestEvaluateCandidate:
             maturity_years=0.25,
             crash_pct=-25.0,
             crash_vol_shock=_CRASH_VOL_SHOCK,
+            skew_steepening=_SKEW_STEEPENING,
+            skew_reference_delta=_SKEW_REFERENCE_DELTA,
         )
         assert result.put_delta < 0.0
 
@@ -135,6 +147,8 @@ class TestEvaluateCandidate:
             maturity_years=0.25,
             crash_pct=-25.0,
             crash_vol_shock=_CRASH_VOL_SHOCK,
+            skew_steepening=_SKEW_STEEPENING,
+            skew_reference_delta=_SKEW_REFERENCE_DELTA,
         )
         assert result.per_contract_intrinsic_floor == pytest.approx(100_000.0)
         assert result.per_contract_payoff > 0.0
@@ -154,6 +168,8 @@ class TestEvaluateCandidate:
             maturity_years=0.25,
             crash_pct=-25.0,
             crash_vol_shock=_CRASH_VOL_SHOCK,
+            skew_steepening=_SKEW_STEEPENING,
+            skew_reference_delta=_SKEW_REFERENCE_DELTA,
         )
         assert result.per_contract_intrinsic_floor == pytest.approx(0.0)
         assert result.per_contract_payoff > 0.0
@@ -167,6 +183,8 @@ class TestEvaluateCandidate:
             maturity_years=0.25,
             crash_pct=-25.0,
             crash_vol_shock=_CRASH_VOL_SHOCK,
+            skew_steepening=_SKEW_STEEPENING,
+            skew_reference_delta=_SKEW_REFERENCE_DELTA,
         )
         assert result.per_contract_carry > 0.0
 
@@ -179,6 +197,8 @@ class TestEvaluateCandidate:
             maturity_years=0.25,
             crash_pct=-25.0,
             crash_vol_shock=_CRASH_VOL_SHOCK,
+            skew_steepening=_SKEW_STEEPENING,
+            skew_reference_delta=_SKEW_REFERENCE_DELTA,
         )
         assert result.premium > 0.0
 
@@ -191,6 +211,8 @@ class TestEvaluateCandidate:
             maturity_years=0.50,
             crash_pct=-30.0,
             crash_vol_shock=_CRASH_VOL_SHOCK,
+            skew_steepening=_SKEW_STEEPENING,
+            skew_reference_delta=_SKEW_REFERENCE_DELTA,
         )
         assert result.strike == pytest.approx(4600.0)
 
@@ -203,6 +225,8 @@ class TestEvaluateCandidate:
             maturity_years=0.25,
             crash_pct=-25.0,
             crash_vol_shock=_CRASH_VOL_SHOCK,
+            skew_steepening=_SKEW_STEEPENING,
+            skew_reference_delta=_SKEW_REFERENCE_DELTA,
             vol=0.15,
         )
         r_high = evaluate_candidate(
@@ -211,6 +235,8 @@ class TestEvaluateCandidate:
             maturity_years=0.25,
             crash_pct=-25.0,
             crash_vol_shock=_CRASH_VOL_SHOCK,
+            skew_steepening=_SKEW_STEEPENING,
+            skew_reference_delta=_SKEW_REFERENCE_DELTA,
             vol=0.30,
         )
         assert r_high.premium > r_low.premium
@@ -228,6 +254,8 @@ class TestEvaluateCandidate:
             "strike": 3500.0,  # OTM at the -25% crash → time value only
             "maturity_years": 0.5,
             "crash_pct": -25.0,
+            "skew_steepening": _SKEW_STEEPENING,
+            "skew_reference_delta": _SKEW_REFERENCE_DELTA,
         }
         r_low = evaluate_candidate(portfolio, **kwargs, crash_vol_shock=0.05)
         r_high = evaluate_candidate(portfolio, **kwargs, crash_vol_shock=0.25)
@@ -242,6 +270,8 @@ class TestEvaluateCandidate:
             maturity_years=0.25,
             crash_pct=-25.0,
             crash_vol_shock=_CRASH_VOL_SHOCK,
+            skew_steepening=_SKEW_STEEPENING,
+            skew_reference_delta=_SKEW_REFERENCE_DELTA,
         )
         assert result.per_contract_carry > 0.0
 
@@ -258,6 +288,8 @@ class TestCandidateContractSizeScaling:
             "maturity_years": 0.25,
             "crash_pct": -25.0,
             "crash_vol_shock": _CRASH_VOL_SHOCK,
+            "skew_steepening": _SKEW_STEEPENING,
+            "skew_reference_delta": _SKEW_REFERENCE_DELTA,
         }
         r100 = evaluate_candidate(p100, **kwargs)
         r50 = evaluate_candidate(p50, **kwargs)
@@ -272,6 +304,8 @@ class TestCandidateContractSizeScaling:
             "maturity_years": 0.25,
             "crash_pct": -25.0,
             "crash_vol_shock": _CRASH_VOL_SHOCK,
+            "skew_steepening": _SKEW_STEEPENING,
+            "skew_reference_delta": _SKEW_REFERENCE_DELTA,
         }
         r100 = evaluate_candidate(p100, **kwargs)
         r50 = evaluate_candidate(p50, **kwargs)
@@ -288,6 +322,8 @@ class TestCandidateContractSizeScaling:
             "maturity_years": 0.25,
             "crash_pct": -25.0,
             "crash_vol_shock": _CRASH_VOL_SHOCK,
+            "skew_steepening": _SKEW_STEEPENING,
+            "skew_reference_delta": _SKEW_REFERENCE_DELTA,
         }
         r100 = evaluate_candidate(p100, **kwargs)
         r50 = evaluate_candidate(p50, **kwargs)
@@ -304,6 +340,8 @@ class TestCandidateContractSizeScaling:
             "maturity_years": 0.25,
             "crash_pct": -25.0,
             "crash_vol_shock": _CRASH_VOL_SHOCK,
+            "skew_steepening": _SKEW_STEEPENING,
+            "skew_reference_delta": _SKEW_REFERENCE_DELTA,
         }
         assert evaluate_candidate(p100, **kwargs).pct_otm == pytest.approx(
             evaluate_candidate(p50, **kwargs).pct_otm,
@@ -328,6 +366,8 @@ class TestCrashRepricingBasis:
                 maturity_years=_APX_MATURITY_YEARS,
                 crash_pct=_APX_CRASH_PCT,
                 crash_vol_shock=_APX_VOL_SHOCK,
+                skew_steepening=_SKEW_STEEPENING,
+                skew_reference_delta=_SKEW_REFERENCE_DELTA,
             )
             assert result.per_contract_payoff > 0.0
             assert result.per_contract_intrinsic_floor == pytest.approx(0.0)
@@ -349,6 +389,8 @@ class TestCrashRepricingBasis:
             maturity_years=_APX_MATURITY_YEARS,
             crash_pct=_APX_CRASH_PCT,
             crash_vol_shock=_APX_VOL_SHOCK,
+            skew_steepening=_SKEW_STEEPENING,
+            skew_reference_delta=_SKEW_REFERENCE_DELTA,
         )
         assert result.per_contract_intrinsic_floor == pytest.approx(33_000.0)
         assert result.per_contract_intrinsic_floor < result.per_contract_payoff
@@ -382,12 +424,16 @@ class TestCrashRepricingBasis:
             maturity_years=_APX_MATURITY_YEARS,
             crash_pct=_APX_CRASH_PCT,
             crash_vol_shock=_APX_VOL_SHOCK,
+            skew_steepening=_SKEW_STEEPENING,
+            skew_reference_delta=_SKEW_REFERENCE_DELTA,
         )
         ips = IpsConvexity(
             crash_scenario_pct=_APX_CRASH_PCT,
             target_min_pct=15.0,
             target_max_pct=25.0,
             crash_vol_shock=_APX_VOL_SHOCK,
+            skew_steepening=_SKEW_STEEPENING,
+            skew_reference_delta=_SKEW_REFERENCE_DELTA,
         )
         rows = crash_scenario_table(
             portfolio,
@@ -396,6 +442,115 @@ class TestCrashRepricingBasis:
         )
         row = next(r for r in rows if r.shock_pct == _APX_CRASH_PCT)
         assert candidate.per_contract_payoff == pytest.approx(row.hedge_pnl)
+
+
+class TestBookCandidateParity:
+    """M1.7 — one skew function drives book legs and standalone candidates."""
+
+    def test_book_equals_candidate_at_equal_depth(self) -> None:
+        """A candidate equals the held leg's per-contract crash value.
+
+        The headline guard: evaluating a candidate at a strike/tenor the book
+        already holds must reproduce that held leg's repriced per-contract crash
+        value exactly.  Both flow through the per-leg skew in crash_hedge_value,
+        anchored to the leg's own wing, so book and workbench cannot disagree at
+        equal depth.
+        """
+        from deltadewa.analysis.crash_repricing import crash_hedge_value
+
+        strike = _APX_STRIKE_30_OTM
+        quantity = 7  # > 1 so the per-contract division is exercised
+        portfolio = _make_appendix_portfolio()
+        maturity_date = portfolio.valuation_date + datetime.timedelta(
+            days=round(_APX_MATURITY_YEARS * const.DAYS_PER_YEAR),
+        )
+        portfolio.add_position(
+            strike_price=strike,
+            maturity_date=maturity_date,
+            quantity=quantity,
+            option_type=OptionType.PUT,
+            volatility=_APX_VOL,
+        )
+        held_leg = portfolio.positions[0]
+
+        held_total = crash_hedge_value(
+            portfolio,
+            crash_move=_APX_CRASH_PCT / 100.0,
+            vol_shock=_APX_VOL_SHOCK,
+            skew_steepening=_SKEW_STEEPENING,
+            skew_reference_delta=_SKEW_REFERENCE_DELTA,
+            positions=[held_leg],
+        )
+        held_per_contract = held_total / quantity
+
+        candidate = evaluate_candidate(
+            portfolio,
+            strike=strike,
+            maturity_years=_APX_MATURITY_YEARS,
+            crash_pct=_APX_CRASH_PCT,
+            crash_vol_shock=_APX_VOL_SHOCK,
+            skew_steepening=_SKEW_STEEPENING,
+            skew_reference_delta=_SKEW_REFERENCE_DELTA,
+        )
+        assert candidate.per_contract_payoff == pytest.approx(held_per_contract)
+
+    def test_candidate_payoff_rises_vs_flat_bump(self) -> None:
+        """Skew-on lifts the candidate payoff above the old flat bump.
+
+        The per-leg steepening adds vol on top of ``crash_vol_shock`` for an OTM
+        put, so the repriced payoff is strictly larger than the flat-bump value
+        the candidate path produced before M1.7 (the ~23% under-statement is
+        gone).
+        """
+        portfolio = _make_appendix_portfolio()
+        common = {
+            "strike": _APX_STRIKE_30_OTM,
+            "maturity_years": _APX_MATURITY_YEARS,
+            "crash_pct": _APX_CRASH_PCT,
+            "crash_vol_shock": _APX_VOL_SHOCK,
+            "skew_reference_delta": _SKEW_REFERENCE_DELTA,
+        }
+        flat = evaluate_candidate(portfolio, **common, skew_steepening=0.0)
+        skewed = evaluate_candidate(
+            portfolio,
+            **common,
+            skew_steepening=_SKEW_STEEPENING,
+        )
+        assert skewed.per_contract_payoff > flat.per_contract_payoff
+
+    def test_candidate_payoff_independent_of_book_composition(self) -> None:
+        """A candidate's payoff does not change when the book changes.
+
+        The candidate is priced in isolation on its own wing (no book context),
+        so adding a deeper held put to the portfolio must not move its payoff —
+        the M1.7 composition-independence guarantee, on the candidate path.
+        """
+        kwargs = {
+            "strike": _APX_STRIKE_20_OTM,
+            "maturity_years": _APX_MATURITY_YEARS,
+            "crash_pct": _APX_CRASH_PCT,
+            "crash_vol_shock": _APX_VOL_SHOCK,
+            "skew_steepening": _SKEW_STEEPENING,
+            "skew_reference_delta": _SKEW_REFERENCE_DELTA,
+        }
+        empty_book = _make_appendix_portfolio()
+        before = evaluate_candidate(empty_book, **kwargs)
+
+        with_deeper = _make_appendix_portfolio()
+        maturity_date = with_deeper.valuation_date + datetime.timedelta(
+            days=round(_APX_MATURITY_YEARS * const.DAYS_PER_YEAR),
+        )
+        with_deeper.add_position(
+            strike_price=_APX_STRIKE_40_OTM,
+            maturity_date=maturity_date,
+            quantity=50,
+            option_type=OptionType.PUT,
+            volatility=_APX_VOL,
+        )
+        after = evaluate_candidate(with_deeper, **kwargs)
+        assert after.per_contract_payoff == pytest.approx(
+            before.per_contract_payoff,
+        )
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_analysis/test_crash_payoff.py
+++ b/tests/test_analysis/test_crash_payoff.py
@@ -359,10 +359,12 @@ class TestCrashPayoffRatio:
         convexity_no_book = analyzer_no_book.calculate_crash_convexity_pct(
             crash_scenario_pct=-25.0,
             crash_vol_shock=0.0,
+            skew_steepening=0.0,
         )
         convexity_with_book = analyzer_with_book.calculate_crash_convexity_pct(
             crash_scenario_pct=-25.0,
             crash_vol_shock=0.0,
+            skew_steepening=0.0,
         )
         assert convexity_no_book == pytest.approx(0.0, rel=1e-4)
         assert convexity_with_book != 0.0
@@ -521,10 +523,12 @@ class TestCrashScenarioTable:
         convexity_25 = analyzer.calculate_crash_convexity_pct(
             crash_scenario_pct=-25.0,
             crash_vol_shock=vol_shock,
+            skew_steepening=0.0,
         )
         convexity_10 = analyzer.calculate_crash_convexity_pct(
             crash_scenario_pct=-10.0,
             crash_vol_shock=vol_shock,
+            skew_steepening=0.0,
         )
         assert convexity_10 != pytest.approx(convexity_25)
 

--- a/tests/test_analysis/test_crash_repricing.py
+++ b/tests/test_analysis/test_crash_repricing.py
@@ -27,6 +27,7 @@ from deltadewa.constants import ExerciseStyle, OptionType
 from deltadewa.ips_config import IpsConvexity
 from deltadewa.persistence import PortfolioSerializer
 from deltadewa.portfolio.core import OptionPortfolio
+from deltadewa.portfolio.position import OptionPosition
 from deltadewa.valuation import OptionValuation
 from deltadewa.widgets.summary import NetHedgeSummary
 
@@ -35,9 +36,11 @@ _APPENDIX_SPOT = 6600.0
 _APPENDIX_BOOK = 20_000_000.0
 _APPENDIX_MOVE = -0.25
 _APPENDIX_VOL_SHOCK = 0.15
-# Shipped deep-OTM skew steepening (M1.6): extra vol at the deepest tail over
-# ATM, linear in log-moneyness. The §4 worked example is now skew-aware.
+# Shipped deep-OTM skew steepening (M1.6/M1.7): extra vol reached at each leg's
+# own ~10-delta wing, capped there and interpolated (in log-moneyness) below it.
+# The §4 worked example is skew-aware; the anchor is per-leg, not book-relative.
 _APPENDIX_SKEW = 0.10
+_APPENDIX_SKEW_ANCHOR = 0.10
 # (strike, contract count) for the 20/30/40%-OTM three-rung ladder.
 _APPENDIX_LEGS = ((5280.0, 23), (4620.0, 26), (3960.0, 16))
 
@@ -140,12 +143,38 @@ def _load_golden_20m_example() -> OptionPortfolio:
     return result["portfolio"]
 
 
+def _leg_extra_crash_vol(
+    portfolio: OptionPortfolio,
+    position: OptionPosition,
+    *,
+    skew: float = _APPENDIX_SKEW,
+    anchor: float = _APPENDIX_SKEW_ANCHOR,
+) -> float:
+    """Per-leg crash-vol steepening above ``vol_i + vol_shock`` (test helper).
+
+    Drives the production per-leg helper with the portfolio's market snapshot
+    and returns the add-on the wing steepening applies to this leg alone.
+    """
+    crash_vol = cr._leg_crash_vol(
+        position,
+        spot=portfolio.spot_price,
+        risk_free_rate=portfolio.risk_free_rate,
+        dividend_yield=portfolio.dividend_yield,
+        valuation_date=portfolio.valuation_date,
+        vol_shock=_APPENDIX_VOL_SHOCK,
+        skew_steepening=skew,
+        skew_reference_delta=anchor,
+    )
+    return crash_vol - (position.option.volatility + _APPENDIX_VOL_SHOCK)
+
+
 class TestAppendixGoldenValues:
     """§7.1 — the §4 worked example reprices to the published figures.
 
-    The shipped shock is skew-aware (``_APPENDIX_SKEW``); these anchors are the
-    post-M1.6 §4 goldens. The flat-bump baseline (``+18.0%`` / ``13.1x``) is
-    pinned separately by :class:`TestSkewSteepeningNoOp` at ``skew=0.0``.
+    The shipped shock is skew-aware (``_APPENDIX_SKEW``), anchored per-leg to
+    each leg's own ~10-delta wing (M1.7); these anchors are the post-M1.7 §4
+    goldens. The flat-bump baseline (``+18.0%`` / ``13.1x``) is pinned
+    separately by :class:`TestSkewSteepeningNoOp` at ``skew=0.0``.
     """
 
     def test_hedge_values_within_tolerance(self) -> None:
@@ -162,10 +191,10 @@ class TestAppendixGoldenValues:
 
         # V_today is skew-free (skew is a crash-state effect only).
         assert v_today == pytest.approx(297_715.0, rel=0.005)
-        assert v_crash == pytest.approx(4_788_166.0, rel=0.005)
+        assert v_crash == pytest.approx(5_226_004.0, rel=0.005)
 
-    def test_convexity_is_plus_22_pct(self) -> None:
-        """Crash convexity is +22.5% ± epsilon — inside the IPS band."""
+    def test_convexity_is_in_band_near_ceiling(self) -> None:
+        """Crash convexity is +24.6% ± epsilon — inside the IPS band."""
         portfolio = _make_appendix_book()
 
         convexity = cr.crash_convexity_pct(
@@ -175,10 +204,11 @@ class TestAppendixGoldenValues:
             skew_steepening=_APPENDIX_SKEW,
         )
 
-        assert convexity == pytest.approx(22.5, abs=0.5)
+        assert convexity == pytest.approx(24.64, abs=0.1)
+        assert 15.0 <= convexity <= 25.0
 
-    def test_payoff_ratio_is_about_16x(self) -> None:
-        """The repriced headline payoff ratio is ~16x (not the 2.5x floor)."""
+    def test_payoff_ratio_is_about_17x(self) -> None:
+        """The repriced headline payoff ratio is ~17.5x (not the 2.5x floor)."""
         portfolio = _make_appendix_book()
         ips = IpsConvexity(
             crash_scenario_pct=-25.0,
@@ -196,7 +226,7 @@ class TestAppendixGoldenValues:
         )
 
         assert result.payoff_ratio is not None
-        assert result.payoff_ratio == pytest.approx(16.1, rel=0.02)
+        assert result.payoff_ratio == pytest.approx(17.53, rel=0.02)
 
     def test_intrinsic_floor_is_the_conservative_759k(self) -> None:
         """The intrinsic floor (~$759k) is far below the repriced value."""
@@ -309,35 +339,50 @@ class TestSkewSteepeningBehaviour:
 
         assert steepened > flat
 
-    def test_weights_are_linear_in_log_moneyness(self) -> None:
-        """V_crash matches the leg vols rebuilt from the log-moneyness form.
+    def test_crash_vol_matches_per_leg_wing_formula(self) -> None:
+        """V_crash matches the leg vols rebuilt from the per-leg wing form.
 
-        Independently reconstructs each leg's shocked vol as
-        ``0.20 + vol_shock + skew * w`` with ``w = ln(S/K) / ln(S/K_tail)``,
-        prices with the public engine, and requires an exact match — pinning
-        the interpolation to log-moneyness with the deepest OTM put as anchor.
+        Independently reconstructs each put leg's shocked vol as
+        ``0.20 + vol_shock + min(skew, slope * ln(S/K))`` with
+        ``slope = skew / ln(S / K_ref)`` and ``K_ref`` the leg's own ~10-delta
+        wing, prices with the public engine, and requires an exact match —
+        pinning the crash vol to the per-leg wing anchor and the cap (M1.7),
+        not the old book-relative deepest-put anchor.
         """
         portfolio = _make_appendix_book()
-        skew = 0.10
+        skew = _APPENDIX_SKEW
 
         got = cr.crash_hedge_value(
             portfolio,
             crash_move=_APPENDIX_MOVE,
             vol_shock=_APPENDIX_VOL_SHOCK,
             skew_steepening=skew,
+            skew_reference_delta=_APPENDIX_SKEW_ANCHOR,
         )
 
         crash_spot = _APPENDIX_SPOT * (1.0 + _APPENDIX_MOVE)
-        deepest_strike = min(strike for strike, _ in _APPENDIX_LEGS)
-        tail_log_moneyness = math.log(_APPENDIX_SPOT / deepest_strike)
         expected = 0.0
         for position in portfolio.positions:
             strike = position.option.strike_price
-            weight = min(
-                1.0,
-                math.log(_APPENDIX_SPOT / strike) / tail_log_moneyness,
+            is_otm_put = (
+                position.option.option_type == OptionType.PUT
+                and strike < _APPENDIX_SPOT
             )
-            vol = 0.20 + _APPENDIX_VOL_SHOCK + skew * weight
+            if is_otm_put:
+                k_ref = cr._solve_wing_strike(
+                    spot=_APPENDIX_SPOT,
+                    maturity_date=position.option.maturity_date,
+                    volatility=position.option.volatility,
+                    risk_free_rate=portfolio.risk_free_rate,
+                    dividend_yield=portfolio.dividend_yield,
+                    valuation_date=portfolio.valuation_date,
+                    anchor_delta=_APPENDIX_SKEW_ANCHOR,
+                )
+                slope = skew / math.log(_APPENDIX_SPOT / k_ref)
+                extra = min(skew, slope * math.log(_APPENDIX_SPOT / strike))
+            else:
+                extra = 0.0
+            vol = 0.20 + _APPENDIX_VOL_SHOCK + extra
             leg = OptionValuation(
                 spot_price=crash_spot,
                 strike_price=strike,
@@ -370,6 +415,129 @@ class TestSkewSteepeningBehaviour:
         )
 
         assert steepened == flat
+
+
+class TestPerLegWingAnchor:
+    """M1.7 — the skew is a pure per-leg function of the leg's own wing.
+
+    Pins the re-anchoring this milestone exists to make: the extra crash vol on
+    each leg is ``min(skew, slope * ln(S/K))`` against that leg's own ~10-delta
+    wing, capped there, and independent of what else the book holds. The values
+    match ``scratch/skew_anchor_sweep.py`` rule (e), the signed-off calibration.
+    """
+
+    def test_per_leg_extra_vol_matches_sweep_canonical(self) -> None:
+        """Canonical legs steepen to their own wing: K5200 +5.77, K4900 +7.67.
+
+        Both legs are shallower than their own ~10-delta wing, so neither is
+        capped — the extra interpolates below +10 vol pts.
+        """
+        portfolio = _load_canonical_example()
+        extras = {
+            pos.option.strike_price: _leg_extra_crash_vol(portfolio, pos)
+            for pos in portfolio.positions
+            if pos.option.option_type == OptionType.PUT
+        }
+
+        assert extras[5200.0] == pytest.approx(0.0577, abs=0.0015)
+        assert extras[4900.0] == pytest.approx(0.0767, abs=0.0015)
+        # Neither shallow leg reaches the cap.
+        assert extras[5200.0] < _APPENDIX_SKEW
+        assert extras[4900.0] < _APPENDIX_SKEW
+
+    def test_per_leg_extra_vol_matches_sweep_appendix(self) -> None:
+        """§4 legs: K5280 +9.46, K4620 and K3960 pinned at the +10 cap."""
+        portfolio = _make_appendix_book()
+        extras = {
+            pos.option.strike_price: _leg_extra_crash_vol(portfolio, pos)
+            for pos in portfolio.positions
+        }
+
+        assert extras[5280.0] == pytest.approx(0.0946, abs=0.0015)
+        assert extras[5280.0] < _APPENDIX_SKEW
+        # The two deeper legs sit at or beyond their wing -> capped at skew.
+        assert extras[4620.0] == pytest.approx(_APPENDIX_SKEW, abs=1e-9)
+        assert extras[3960.0] == pytest.approx(_APPENDIX_SKEW, abs=1e-9)
+
+    def test_crash_vol_independent_of_book_composition(self) -> None:
+        """Adding a deeper put leaves a shallower leg's crash vol unchanged.
+
+        The M1.7 acceptance criterion: market skew at a strike is not a function
+        of what else is held. Under the old book-relative anchor the shallow
+        leg's steepening tracked the *deepest held* put; here it tracks the
+        leg's own wing, so a new, deeper leg cannot move it.
+        """
+        portfolio = _make_appendix_book()  # deepest held put is K3960
+        shallow = next(
+            pos
+            for pos in portfolio.positions
+            if pos.option.strike_price == 5280.0
+        )
+
+        before = _leg_extra_crash_vol(portfolio, shallow)
+
+        # Add a leg deeper than the existing deepest (K3960 -> K3000).
+        portfolio.add_position(
+            strike_price=3000.0,
+            maturity_date=shallow.option.maturity_date,
+            quantity=5,
+            option_type=OptionType.PUT,
+            volatility=0.20,
+        )
+        after = _leg_extra_crash_vol(portfolio, shallow)
+
+        # The shallow leg's crash vol does not move.
+        assert after == before
+        # ...and it is the own-wing value, not the book-relative (deepest-put)
+        # weight the old model would have produced.
+        book_relative = _APPENDIX_SKEW * (
+            math.log(_APPENDIX_SPOT / 5280.0)
+            / math.log(_APPENDIX_SPOT / 3960.0)
+        )
+        assert before == pytest.approx(0.0946, abs=0.0015)
+        assert before != pytest.approx(book_relative, abs=0.001)
+
+    def test_cap_binds_at_and_beyond_the_wing(self) -> None:
+        """Extra vol == skew at/beyond the wing; interpolates below it."""
+        portfolio = _make_appendix_book()
+        maturity = portfolio.positions[0].option.maturity_date
+        k_wing = cr._solve_wing_strike(
+            spot=_APPENDIX_SPOT,
+            maturity_date=maturity,
+            volatility=0.20,
+            risk_free_rate=portfolio.risk_free_rate,
+            dividend_yield=portfolio.dividend_yield,
+            valuation_date=portfolio.valuation_date,
+            anchor_delta=_APPENDIX_SKEW_ANCHOR,
+        )
+
+        # Three probe puts: shallower than the wing, at it, and deeper than it.
+        probe = OptionPortfolio(
+            spot_price=_APPENDIX_SPOT,
+            volatility=0.20,
+            risk_free_rate=0.045,
+            dividend_yield=0.015,
+            underlying_quantity=1000.0,
+            default_exercise_style=ExerciseStyle.EUROPEAN,
+            valuation_date=portfolio.valuation_date,
+        )
+        for strike in (k_wing * 1.1, k_wing, k_wing * 0.85):
+            probe.add_position(
+                strike_price=strike,
+                maturity_date=maturity,
+                quantity=1,
+                option_type=OptionType.PUT,
+                volatility=0.20,
+            )
+        shallow_extra, at_wing_extra, deep_extra = (
+            _leg_extra_crash_vol(probe, pos) for pos in probe.positions
+        )
+
+        # Exactly the cap at the wing, and still capped beyond it.
+        assert at_wing_extra == pytest.approx(_APPENDIX_SKEW, abs=1e-9)
+        assert deep_extra == pytest.approx(_APPENDIX_SKEW, abs=1e-9)
+        # Below the wing the steepening interpolates strictly under the cap.
+        assert 0.0 < shallow_extra < _APPENDIX_SKEW
 
 
 class TestBand:
@@ -424,10 +592,10 @@ class TestGoldenExampleFile:
         )
 
         assert v_today == pytest.approx(297_715.0, rel=0.005)
-        assert v_crash == pytest.approx(4_788_166.0, rel=0.005)
+        assert v_crash == pytest.approx(5_226_004.0, rel=0.005)
 
     def test_example_convexity_is_in_band(self) -> None:
-        """Loaded book reprices to +22.5% ± epsilon — inside +15..+25%."""
+        """Loaded book reprices to +24.6% ± epsilon — inside +15..+25%."""
         portfolio = _load_golden_20m_example()
 
         convexity = cr.crash_convexity_pct(
@@ -437,7 +605,7 @@ class TestGoldenExampleFile:
             skew_steepening=_APPENDIX_SKEW,
         )
 
-        assert convexity == pytest.approx(22.5, abs=0.5)
+        assert convexity == pytest.approx(24.64, abs=0.1)
         assert 15.0 <= convexity <= 25.0
 
 

--- a/tests/test_analysis/test_crash_repricing.py
+++ b/tests/test_analysis/test_crash_repricing.py
@@ -830,12 +830,14 @@ class TestNoLegacyBasisInConvexityPaths:
 
 
 class TestCanonicalExampleInvariants:
-    """§7 — invariants only on spx_protective_put.yaml (not the band).
+    """§7 — invariants on spx_protective_put.yaml, plus the in-band re-golden.
 
-    Measured corrected convexity at the IPS scenario (-25%, vol_shock 0.15) is
-    ~+14.3% of the ~$5.8M book — positive, hedge-only, and repriced, but a
-    touch below the +15..+25% band floor. That marginal under-sizing is an
-    M1.4 (Mo3) re-sizing item; it is deliberately not re-sized here.
+    Under the *flat* bump the corrected convexity at the IPS scenario (-25%,
+    vol_shock 0.15) is ~+14.3% of the ~$5.8M book — positive, hedge-only, and
+    repriced, but a touch below the +15..+25% floor. The shipped per-leg skew
+    shock (M1.7) lifts it to ~+16.1%, comfortably in-band, so the book is
+    conformant and **not re-sized** — asserted in
+    :meth:`test_canonical_in_band_under_skew_not_resized`.
     """
 
     def test_convexity_is_positive(self) -> None:
@@ -871,6 +873,37 @@ class TestCanonicalExampleInvariants:
                 pos.option.volatility + 0.15,
             )
             assert value > 0.0
+
+    def test_canonical_in_band_under_skew_not_resized(self) -> None:
+        """Per-leg skew lifts the canonical to ~+16.1% — in-band, not re-sized.
+
+        The flat bump left it just under the +15% floor (~+14.3%); the
+        honestly-calibrated per-leg wing steepening (M1.7) reads ~+16.1%,
+        comfortably in the +15..+25% band, so no re-size is needed. The fixture
+        carries an *absolute* maturity, so the valuation date is pinned here to
+        keep the golden stable against day-to-day theta drift.
+        """
+        portfolio = _load_canonical_example()
+        portfolio.valuation_date = datetime(2026, 7, 25, tzinfo=UTC)
+
+        convexity = cr.crash_convexity_pct(
+            portfolio,
+            crash_move=_APPENDIX_MOVE,
+            vol_shock=_APPENDIX_VOL_SHOCK,
+            skew_steepening=_APPENDIX_SKEW,
+            skew_reference_delta=_APPENDIX_SKEW_ANCHOR,
+        )
+
+        assert convexity == pytest.approx(16.1, abs=0.1)
+        # In-band => the conformance conclusion is "no re-size needed".
+        assert 15.0 <= convexity <= 25.0
+        # ...and the fixture itself is unchanged: two puts, same strikes/counts.
+        puts = {
+            (pos.option.strike_price, pos.quantity)
+            for pos in portfolio.positions
+            if pos.option.option_type == OptionType.PUT
+        }
+        assert puts == {(5200.0, 5), (4900.0, 5)}
 
 
 class TestPerLegExerciseStyleRespected:

--- a/tests/test_analysis/test_crash_repricing.py
+++ b/tests/test_analysis/test_crash_repricing.py
@@ -20,11 +20,23 @@ import pytest
 from deltadewa.analysis import classify_portfolio_shape
 from deltadewa.analysis import crash_repricing as cr
 from deltadewa.analysis.base import PortfolioAnalyzer
-from deltadewa.analysis.crash_payoff import compute_crash_convexity
+from deltadewa.analysis.crash_payoff import (
+    compute_crash_convexity,
+    crash_scenario_table,
+)
 from deltadewa.analysis.health import HealthMixin
 from deltadewa.analysis.roll_status import evaluate_roll_status
 from deltadewa.constants import ExerciseStyle, OptionType
-from deltadewa.ips_config import IpsConvexity
+from deltadewa.ips_config import (
+    IpsBudget,
+    IpsConfig,
+    IpsConvexity,
+    IpsDrawdown,
+    IpsMonetization,
+    IpsPricing,
+    IpsProgram,
+    IpsTriggers,
+)
 from deltadewa.persistence import PortfolioSerializer
 from deltadewa.portfolio.core import OptionPortfolio
 from deltadewa.portfolio.position import OptionPosition
@@ -168,6 +180,39 @@ def _leg_extra_crash_vol(
     return crash_vol - (position.option.volatility + _APPENDIX_VOL_SHOCK)
 
 
+def _make_appendix_ips(*, crash_scenario_pct: float) -> IpsConfig:
+    """Full IpsConfig at the appendix crash knobs, parameterised on depth.
+
+    Carries the shipped skew-aware shock (``_APPENDIX_VOL_SHOCK`` /
+    ``_APPENDIX_SKEW`` / ``_APPENDIX_SKEW_ANCHOR``) so every surface driven from
+    this one config shares a single crash basis. Only ``crash_scenario_pct``
+    varies, so the roll trigger evaluates convexity at the chosen depth.
+    """
+    return IpsConfig(
+        program=IpsProgram(name="appendix", instrument="SPX"),
+        pricing=IpsPricing(exercise_style=ExerciseStyle.EUROPEAN),
+        budget=IpsBudget(annual_carry_pct=2.0),
+        convexity=IpsConvexity(
+            crash_scenario_pct=crash_scenario_pct,
+            target_min_pct=15.0,
+            target_max_pct=25.0,
+            crash_vol_shock=_APPENDIX_VOL_SHOCK,
+            skew_steepening=_APPENDIX_SKEW,
+            skew_reference_delta=_APPENDIX_SKEW_ANCHOR,
+        ),
+        drawdown=IpsDrawdown(max_tolerance_pct=20.0),
+        triggers=IpsTriggers(
+            delta_drift_warn_pct=5.0,
+            delta_drift_action_pct=10.0,
+            theta_cost_acceptable_pct=2.0,
+            roll_time_months=1.0,
+            rally_rebalance_pct=15.0,
+            strike_drift_max_otm_pct=45.0,
+        ),
+        monetization=IpsMonetization(schedule=()),
+    )
+
+
 class TestAppendixGoldenValues:
     """§7.1 — the §4 worked example reprices to the published figures.
 
@@ -194,7 +239,18 @@ class TestAppendixGoldenValues:
         assert v_crash == pytest.approx(5_226_004.0, rel=0.005)
 
     def test_convexity_is_in_band_near_ceiling(self) -> None:
-        """Crash convexity is +24.6% ± epsilon — inside the IPS band."""
+        """§4 reprices to +24.64% — the VALUE anchor, riding just under +25%.
+
+        This value assertion (not the ``meets_target`` boolean in
+        :class:`TestBand`) is the §4 regression anchor. §4 is a deliberately
+        deep 20/30/40 ladder, so a faithful crash model correctly places it near
+        the top of the +15..+25% band — it rides only 0.36pp under the +25% IPS
+        ceiling by design. Pinning the value (not the boolean) makes any future
+        re-calibration that nudges §4 surface as a visible number change
+        demanding a deliberate decision, never a silent ``meets_target`` flip
+        that would masquerade as a regression while the fixture just hugs the
+        rail.
+        """
         portfolio = _make_appendix_book()
 
         convexity = cr.crash_convexity_pct(
@@ -206,6 +262,8 @@ class TestAppendixGoldenValues:
 
         assert convexity == pytest.approx(24.64, abs=0.1)
         assert 15.0 <= convexity <= 25.0
+        # Rides 0.36pp under the +25% IPS ceiling (target_max_pct) by design.
+        assert 25.0 - convexity == pytest.approx(0.36, abs=0.1)
 
     def test_payoff_ratio_is_about_17x(self) -> None:
         """The repriced headline payoff ratio is ~17.5x (not the 2.5x floor)."""
@@ -316,6 +374,32 @@ class TestSkewSteepeningNoOp:
         floor = cr.crash_intrinsic_floor(portfolio, crash_move=_APPENDIX_MOVE)
 
         assert floor == pytest.approx(759_000.0, rel=0.005)
+
+    def test_leg_crash_vol_noop_is_byte_for_byte(self) -> None:
+        """skew=0.0 returns the flat bump exactly, per leg (solves no wing).
+
+        The tightest no-op guard, at the primitive: an explicit
+        ``skew_steepening=0.0`` returns ``vol_i + vol_shock`` byte-for-byte for
+        every leg — including the two deep rungs that WOULD cap under a positive
+        steepening — because the disabled knob short-circuits before any wing is
+        solved. Pins the flat-baseline reproduction the aggregate no-ops need.
+        """
+        portfolio = _make_appendix_book()
+
+        for position in portfolio.positions:
+            flat = position.option.volatility + _APPENDIX_VOL_SHOCK
+            got = cr._leg_crash_vol(
+                position,
+                spot=portfolio.spot_price,
+                risk_free_rate=portfolio.risk_free_rate,
+                dividend_yield=portfolio.dividend_yield,
+                valuation_date=portfolio.valuation_date,
+                vol_shock=_APPENDIX_VOL_SHOCK,
+                skew_steepening=0.0,
+                skew_reference_delta=_APPENDIX_SKEW_ANCHOR,
+            )
+
+            assert got == flat
 
 
 class TestSkewSteepeningBehaviour:
@@ -540,6 +624,51 @@ class TestPerLegWingAnchor:
         assert 0.0 < shallow_extra < _APPENDIX_SKEW
 
 
+class TestCompositionInvariance:
+    """M1.7 — a leg's crash vol is a pure function of its own wing.
+
+    First-class guard (not a sub-assertion): market skew at a strike is not a
+    function of what else the book holds, so adding, removing, or reshuffling
+    other legs must leave every existing leg's crash vol byte-for-byte
+    unchanged. This is the property the per-leg anchor (``b1f4e3d``) exists to
+    provide; the old book-relative anchor, which tracked the deepest held put,
+    failed it.
+    """
+
+    def test_no_leg_crash_vol_depends_on_book_composition(self) -> None:
+        """Every original leg's crash vol is identical after adding others."""
+        portfolio = _make_appendix_book()
+        maturity = portfolio.positions[0].option.maturity_date
+        before = {
+            pos.option.strike_price: _leg_extra_crash_vol(portfolio, pos)
+            for pos in portfolio.positions
+        }
+
+        # Add unrelated legs on both sides of the ladder and a call: none is an
+        # input to any existing leg's own-wing steepening.
+        for strike, opt in (
+            (3000.0, OptionType.PUT),  # deeper than the deepest held put
+            (6000.0, OptionType.PUT),  # shallower than the shallowest
+            (7260.0, OptionType.CALL),  # a call — no wing at all
+        ):
+            portfolio.add_position(
+                strike_price=strike,
+                maturity_date=maturity,
+                quantity=5,
+                option_type=opt,
+                volatility=0.20,
+            )
+
+        after = {
+            pos.option.strike_price: _leg_extra_crash_vol(portfolio, pos)
+            for pos in portfolio.positions
+            if pos.option.strike_price in before
+        }
+
+        # Byte-for-byte: the added legs moved nothing.
+        assert after == before
+
+
 class TestBand:
     """§7.2 (D3) — the band test anchors on the §4 fixture, not the example."""
 
@@ -563,6 +692,10 @@ class TestBand:
         ips_row = next(r for r in result.scenario_rows if r.shock_pct == -25.0)
 
         assert 15.0 <= ips_row.convexity_pct <= 25.0
+        # This exercises the band-comparison mechanics; the §4 regression is
+        # anchored on the convexity VALUE (TestAppendixGoldenValues), not on
+        # this boolean, so a re-calibration reads as a number change there
+        # rather than a silent flip here (§4 rides 0.36pp under the ceiling).
         assert ips_row.meets_target is True
 
 
@@ -607,6 +740,8 @@ class TestGoldenExampleFile:
 
         assert convexity == pytest.approx(24.64, abs=0.1)
         assert 15.0 <= convexity <= 25.0
+        # Rides 0.36pp under the +25% IPS ceiling (target_max_pct) by design.
+        assert 25.0 - convexity == pytest.approx(0.36, abs=0.1)
 
 
 class TestHedgeOnlyInvariant:
@@ -776,6 +911,57 @@ class TestConsistencyAcrossSurfaces:
 
         assert ips_row.convexity_pct == pytest.approx(gauge)
 
+    def test_all_four_surfaces_agree_at_equal_depth(self) -> None:
+        """Gauge == roll trigger == summary ladder == scenario table at -20%.
+
+        The full single-basis contract under the shipped skew-aware shock:
+        driven from one IPS, the health gauge, the roll trigger's convexity,
+        the summary ladder's -20% rung, and the crash_payoff scenario table's
+        -20% row must all agree at the same crash depth. -20% is the one depth
+        present in every surface (the summary ladder gridpoints, the
+        scenario-table defaults, the gauge, and — via ``crash_scenario_pct`` —
+        the roll trigger).
+        """
+        portfolio = _make_appendix_book()
+        ips = _make_appendix_ips(crash_scenario_pct=-20.0)
+        vol_shock = _APPENDIX_VOL_SHOCK
+        skew = _APPENDIX_SKEW
+
+        gauge = PortfolioAnalyzer(portfolio).calculate_crash_convexity_pct(
+            crash_scenario_pct=-20.0,
+            crash_vol_shock=vol_shock,
+            skew_steepening=skew,
+        )
+        roll = evaluate_roll_status(portfolio, ips)[0].crash_convexity_pct
+        summary = NetHedgeSummary(
+            portfolio,
+            crash_vol_shock=vol_shock,
+            skew_steepening=skew,
+        )
+        rung = dict(summary._crash_convexity_rungs())[-20.0]
+        table = compute_crash_convexity(
+            portfolio,
+            crash_vol_shock=vol_shock,
+            skew_steepening=skew,
+            ips_convexity=ips.convexity,
+        )
+        table_row = next(r for r in table.scenario_rows if r.shock_pct == -20.0)
+
+        # All four surfaces read the same convexity at the same depth.
+        assert roll == pytest.approx(gauge)
+        assert rung == pytest.approx(gauge)
+        assert table_row.convexity_pct == pytest.approx(gauge)
+        # ...and the skew-aware path is actually exercised: a flat bump at this
+        # book/depth is a materially different (lower) number, so the agreement
+        # is not a trivial flat-path coincidence.
+        flat = cr.crash_convexity_pct(
+            portfolio,
+            crash_move=-0.20,
+            vol_shock=vol_shock,
+            skew_steepening=0.0,
+        )
+        assert gauge != pytest.approx(flat)
+
 
 class TestNoLegacyBasisInConvexityPaths:
     """§7.5 grep guard — the equity-netted expiry basis is gone (scoped).
@@ -827,6 +1013,33 @@ class TestNoLegacyBasisInConvexityPaths:
         source = inspect.getsource(evaluate_roll_status)
 
         assert "crash_vol_shock=convexity.crash_vol_shock" in source
+
+    def test_skew_steepening_is_required_on_the_gauge(self) -> None:
+        """skew_steepening has no default — every caller must pass it.
+
+        The M1.7 fail-loud guard, mirroring ``crash_vol_shock`` (M1.4/M1.5):
+        with no default, a site that omits the skew cannot silently reprice a
+        flat bump (+18% at §4 instead of +24.6%) and under-report deep-tail
+        convexity. ``skew_reference_delta`` defaults to ``0.10`` (a wing, not a
+        defaulted ``0.0``) and is out of this guard's scope.
+        """
+        param = inspect.signature(
+            HealthMixin.calculate_crash_convexity_pct,
+        ).parameters["skew_steepening"]
+
+        assert param.default is inspect.Parameter.empty
+
+    def test_roll_status_sources_skew_from_ips(self) -> None:
+        """The roll trigger passes the IPS skew, matching the gauge basis."""
+        source = inspect.getsource(evaluate_roll_status)
+
+        assert "skew_steepening=convexity.skew_steepening" in source
+
+    def test_scenario_table_sources_skew_from_ips(self) -> None:
+        """The scenario table sources skew from the IPS, not a flat default."""
+        source = inspect.getsource(crash_scenario_table)
+
+        assert "ips_convexity.skew_steepening" in source
 
 
 class TestCanonicalExampleInvariants:

--- a/tests/test_analysis/test_crash_single_source.py
+++ b/tests/test_analysis/test_crash_single_source.py
@@ -100,10 +100,12 @@ class TestCrashScenarioSingleSource:
         shallow = analyzer.calculate_crash_convexity_pct(
             crash_scenario_pct=_SHALLOW_PCT,
             crash_vol_shock=_VOL_SHOCK,
+            skew_steepening=0.0,
         )
         deep = analyzer.calculate_crash_convexity_pct(
             crash_scenario_pct=_DEEP_PCT,
             crash_vol_shock=_VOL_SHOCK,
+            skew_steepening=0.0,
         )
 
         assert shallow != deep
@@ -204,6 +206,7 @@ class TestRollMatchesGauge:
         return PortfolioAnalyzer(portfolio).calculate_crash_convexity_pct(
             crash_scenario_pct=ips.convexity.crash_scenario_pct,
             crash_vol_shock=ips.convexity.crash_vol_shock,
+            skew_steepening=ips.convexity.skew_steepening,
         )
 
     def test_roll_convexity_equals_gauge_for_same_book(self) -> None:

--- a/tests/test_analysis/test_sizing.py
+++ b/tests/test_analysis/test_sizing.py
@@ -2,10 +2,12 @@
 
 from __future__ import annotations
 
+import datetime
 import sys
 
 import pytest
 
+from deltadewa import constants as const
 from deltadewa.analysis.sizing import (
     HedgeSizingResult,
     UnitSizingResult,
@@ -14,7 +16,7 @@ from deltadewa.analysis.sizing import (
     size_from_unit,
     size_hedge,
 )
-from deltadewa.constants import ExerciseStyle
+from deltadewa.constants import ExerciseStyle, OptionType
 from deltadewa.ips_config import (
     IpsBudget,
     IpsConfig,
@@ -42,6 +44,8 @@ def _make_ips(
     target_min_pct: float = 5.0,
     target_max_pct: float = 30.0,
     portfolio_beta: float = 1.0,
+    skew_steepening: float = 0.0,
+    skew_reference_delta: float = 0.10,
 ) -> IpsConfig:
     return IpsConfig(
         program=IpsProgram(name="Test", instrument="SPX"),
@@ -51,6 +55,8 @@ def _make_ips(
             crash_scenario_pct=crash_scenario_pct,
             target_min_pct=target_min_pct,
             target_max_pct=target_max_pct,
+            skew_steepening=skew_steepening,
+            skew_reference_delta=skew_reference_delta,
         ),
         drawdown=IpsDrawdown(max_tolerance_pct=max_tolerance_pct),
         triggers=IpsTriggers(
@@ -469,3 +475,69 @@ class TestBetaAdjustedSizing:
         assert result.beta_adjusted_notional == pytest.approx(
             result.book_notional * ips.sizing.portfolio_beta,
         )
+
+    def test_sizing_payoff_agrees_with_gauge_at_equal_depth(self) -> None:
+        """size_hedge per-contract payoff equals the book gauge at equal depth.
+
+        The M1.7 acceptance criterion: a candidate sized by the workbench and a
+        held leg priced by the book gauge run through one skew function, so at
+        the same strike/tenor their per-contract crash value is identical — the
+        workbench can no longer under-state payoffs relative to the gauge.
+        """
+        from deltadewa.analysis.crash_repricing import crash_hedge_value
+
+        portfolio = _make_spx_portfolio(spot=5000.0, qty=100.0)
+        ips = _make_ips(skew_steepening=0.10, crash_scenario_pct=-25.0)
+        pct_otm = 30.0
+        maturity_years = 1.5
+
+        sized = size_hedge(
+            portfolio,
+            ips,
+            candidate_pct_otm=pct_otm,
+            candidate_maturity_years=maturity_years,
+        )
+
+        # Book gauge basis: a held leg at the same strike/tenor priced through
+        # the same crash_hedge_value with the IPS skew.
+        strike = portfolio.spot_price * (1.0 - pct_otm / 100.0)
+        maturity_date = portfolio.valuation_date + datetime.timedelta(
+            days=round(maturity_years * const.DAYS_PER_YEAR),
+        )
+        portfolio.add_position(
+            strike_price=strike,
+            maturity_date=maturity_date,
+            quantity=1,
+            option_type=OptionType.PUT,
+            volatility=portfolio.volatility,
+        )
+        gauge_per_contract = crash_hedge_value(
+            portfolio,
+            crash_move=ips.convexity.crash_scenario_pct / 100.0,
+            vol_shock=ips.convexity.crash_vol_shock,
+            skew_steepening=ips.convexity.skew_steepening,
+            skew_reference_delta=ips.convexity.skew_reference_delta,
+            positions=[portfolio.positions[0]],
+        )
+        assert sized.per_contract_payoff == pytest.approx(gauge_per_contract)
+
+    def test_skew_on_raises_payoff_and_not_more_contracts(self) -> None:
+        """Skew-on sizing lifts the payoff and needs no more contracts.
+
+        Turning ``skew_steepening`` on raises the per-contract payoff versus the
+        flat bump, so covering the same crash offset needs no more contracts —
+        the workbench stops over-hedging relative to the gauge (M1.7).
+        """
+        portfolio = _make_spx_portfolio(spot=5000.0, qty=100.0)
+        kwargs = {
+            "candidate_pct_otm": 30.0,
+            "candidate_maturity_years": 1.5,
+        }
+        flat = size_hedge(portfolio, _make_ips(skew_steepening=0.0), **kwargs)
+        skewed = size_hedge(
+            portfolio,
+            _make_ips(skew_steepening=0.10),
+            **kwargs,
+        )
+        assert skewed.per_contract_payoff > flat.per_contract_payoff
+        assert skewed.contracts_needed <= flat.contracts_needed

--- a/tests/test_analysis/test_strike_ladder.py
+++ b/tests/test_analysis/test_strike_ladder.py
@@ -58,6 +58,8 @@ def _make_ips(
     target_min_pct: float = 5.0,
     target_max_pct: float = 30.0,
     portfolio_beta: float = 1.0,
+    skew_steepening: float = 0.0,
+    skew_reference_delta: float = 0.10,
 ) -> IpsConfig:
     return IpsConfig(
         program=IpsProgram(name="Test", instrument="SPX"),
@@ -67,6 +69,8 @@ def _make_ips(
             crash_scenario_pct=crash_scenario_pct,
             target_min_pct=target_min_pct,
             target_max_pct=target_max_pct,
+            skew_steepening=skew_steepening,
+            skew_reference_delta=skew_reference_delta,
         ),
         drawdown=IpsDrawdown(max_tolerance_pct=max_tolerance_pct),
         triggers=IpsTriggers(
@@ -121,6 +125,9 @@ class TestStrikeForDelta:
             maturity_years=0.25,
             crash_pct=-25.0,
             crash_vol_shock=0.15,
+            # put_delta is a today value — skew choice is irrelevant here.
+            skew_steepening=0.0,
+            skew_reference_delta=0.10,
         )
         assert abs(metrics.put_delta) == pytest.approx(target, abs=1e-4)
 
@@ -353,6 +360,8 @@ class TestBuildStrikeLadder:
             maturity_years=0.25,
             crash_pct=crash_pct,
             crash_vol_shock=ips.convexity.crash_vol_shock,
+            skew_steepening=ips.convexity.skew_steepening,
+            skew_reference_delta=ips.convexity.skew_reference_delta,
         )
         offset = required_crash_offset(book_notional, crash_pct, 20.0)
         sizing = size_from_unit(
@@ -372,6 +381,33 @@ class TestBuildStrikeLadder:
         )
         assert rung.within_budget == sizing.within_budget
         assert rung.carry_headroom == pytest.approx(sizing.carry_headroom)
+
+    def test_skew_on_raises_payoff_not_more_contracts(self) -> None:
+        """A skew-on ladder rung pays more and needs no more contracts.
+
+        With ``skew_steepening > 0`` the per-leg wing steepening lifts each
+        rung's repriced payoff above the flat bump, so the same (delta,
+        maturity) cell needs no more contracts to cover the offset — sizing on
+        the unified skew no longer over-hedges (M1.7).
+        """
+        portfolio = _make_spx_portfolio(spot=5000.0, qty=100.0)
+        flat = build_strike_ladder(
+            portfolio,
+            _make_ips(skew_steepening=0.0),
+            target_deltas=[0.10],
+            maturities_years=[1.0],
+        ).rungs[0]
+        skewed = build_strike_ladder(
+            portfolio,
+            _make_ips(skew_steepening=0.10),
+            target_deltas=[0.10],
+            maturities_years=[1.0],
+        ).rungs[0]
+        assert (
+            skewed.metrics.per_contract_payoff
+            > flat.metrics.per_contract_payoff
+        )
+        assert skewed.contracts_needed <= flat.contracts_needed
 
     def test_unsolvable_rung_surfaced_not_dropped(self) -> None:
         """An unsolvable target_delta is surfaced explicitly, not dropped.

--- a/tests/test_ips_config.py
+++ b/tests/test_ips_config.py
@@ -72,6 +72,8 @@ class TestLoadIpsConfig:
         assert ips.convexity.crash_vol_shock == 0.15
         # M1.6: the shipped default adopts the skew-calibrated crash shock.
         assert ips.convexity.skew_steepening == 0.10
+        # M1.7: the steepening is anchored to each leg's ~10-delta wing.
+        assert ips.convexity.skew_reference_delta == 0.10
         assert ips.convexity.crash_floor_reported is True
         assert ips.drawdown.max_tolerance_pct == 20.0
         assert ips.triggers.target_delta_ratio_pct == 90.0
@@ -165,6 +167,7 @@ class TestLoadIpsConfig:
 
         assert ips.convexity.crash_vol_shock == 0.15
         assert ips.convexity.skew_steepening == 0.0
+        assert ips.convexity.skew_reference_delta == 0.10
         assert ips.convexity.crash_floor_reported is True
 
     def test_crash_knobs_round_trip_when_set(self, tmp_path: Path) -> None:
@@ -177,6 +180,7 @@ class TestLoadIpsConfig:
                 "target_max_pct": 25.0,
                 "crash_vol_shock": 0.20,
                 "skew_steepening": 0.30,
+                "skew_reference_delta": 0.15,
                 "crash_floor_reported": False,
             },
         }
@@ -186,6 +190,7 @@ class TestLoadIpsConfig:
 
         assert ips.convexity.crash_vol_shock == 0.20
         assert ips.convexity.skew_steepening == 0.30
+        assert ips.convexity.skew_reference_delta == 0.15
         assert ips.convexity.crash_floor_reported is False
 
     def test_negative_crash_vol_shock_raises(self, tmp_path: Path) -> None:
@@ -218,6 +223,27 @@ class TestLoadIpsConfig:
         path = _write_yaml(tmp_path, config)
 
         with pytest.raises(IpsConfigError, match="skew_steepening"):
+            load_ips_config(path)
+
+    @pytest.mark.parametrize("bad_delta", [0.0, -0.05, 0.5, 0.75])
+    def test_skew_reference_delta_out_of_range_raises(
+        self,
+        tmp_path: Path,
+        bad_delta: float,
+    ) -> None:
+        """A skew_reference_delta outside (0, 0.5) raises IpsConfigError."""
+        config = {
+            **_VALID_CONFIG,
+            "convexity": {
+                "crash_scenario_pct": -25.0,
+                "target_min_pct": 15.0,
+                "target_max_pct": 25.0,
+                "skew_reference_delta": bad_delta,
+            },
+        }
+        path = _write_yaml(tmp_path, config)
+
+        with pytest.raises(IpsConfigError, match="skew_reference_delta"):
             load_ips_config(path)
 
     def test_negative_budget_raises(self, tmp_path: Path) -> None:


### PR DESCRIPTION
## M1.7 — Unify the crash-shock skew across book and candidate surfaces

Closes the last correctness gap before the Dash migration: M1.6 anchored the crash-skew steepening to the book's **deepest held put**, which produced a cross-surface inconsistency with a directional bias. This PR re-anchors the steepening to **each leg's own ~10-delta wing**, unifies it across the book and candidate/sizing surfaces, re-goldens §4 in place, and adds the structural guards that keep it from regressing.

### The problem (M1.6)

- **Book vs workbench split.** Book surfaces priced crash convexity with skew; sizing / strike-ladder / candidate stayed on the flat bump (a standalone candidate had no book tail). Net effect: sizing on the lower flat payoffs **over-hedged ≈23%** relative to the skew gauge — conservative, but a real inconsistency and carry cost.
- **Composition dependence.** Because the anchor was the deepest *held* put, a fixed leg's steepening changed when the book's deepest strike changed — market skew at a strike is not a function of what else is held.

### The fix — one skew function everywhere

`_leg_crash_vol` anchors each leg's steepening to its own ~10-delta wing (`skew_reference_delta`, IPS-configurable, default 0.10), solved per leg via `_solve_wing_strike` and **capped there**. The function takes no book context, so a leg's crash vol is composition-independent; `evaluate_candidate` takes the skew as required params and `size_hedge` / `build_strike_ladder` source them from `ips_config.convexity`.

### Sweep evidence — decisions against measured numbers, not preference

- **D3 — faithful ~10-delta wing anchor, not a %OTM proxy.** A fixed-%OTM proxy only preserved §4's band because §4's tail happens to sit at 40% OTM — a property of *that book*, not the calibration. The delta wing is a market-faithful reference that holds for any book.
- **D5 — cap at the wing, never extrapolate.** No skew calibration exists beyond the ~10-delta wing; extrapolating would fabricate deep-tail IV, and holding flat under-states it (conservative for a tail program). Measured: capping returns §4 from the **uncapped +27.71%** (over the +25% ceiling) to the **in-band +24.64%**.
- **D4 — no canonical re-size.** The canonical reads **+16.10%** under the honest model — **cap-invariant** (its legs are shallower than their wings, so capped == uncapped), **+1.10pp over the +15% floor**. In-band on the honest number, not on M1.6's book-relative artifact ⇒ no re-size.
- **§4 re-goldened in place at +24.64%**, riding **0.36pp under the +25% ceiling by design**, pinned by **value, not the `meets_target` boolean**.

### The five commits

1. `b1f4e3d` — **fix(crash_repricing):** anchor skew to each leg's 10-delta wing, capped (`_tail_log_moneyness` / `_skew_weight` deleted).
2. `c4999f9` — **fix(sizing):** price candidates with the unified skew, removing the flat-bump split.
3. `89f25d3` — **feat(crash):** re-golden §4 under the capped 10-delta anchor and rewrite `docs/repricing-methodology.md` (§2/§4/§5/§7/§8).
4. `6b910ff` — **test(crash):** guard skew consistency, composition invariance, and ceiling proximity.
5. `9a087bf` — **docs(m1.7):** record the auditable close-out (decisions, confirmed numbers, guards).

### Structural guards (keep M1.7 from regressing)

- **Ceiling proximity** — §4 anchored on the convexity **value** (+24.64%, 0.36pp under +25%) with an explicit margin assertion, not the `meets_target` boolean.
- **Four-way consistency** — health gauge == roll trigger == summary ladder == crash_payoff scenario table at equal depth under the skew-aware shock.
- **Composition invariance** — first-class byte-for-byte test: no leg's crash vol depends on what else the book holds.
- **`skew = 0` no-op** — reproduces the flat baseline byte-for-byte at the primitive.
- **Fail-loud** — `skew_steepening` required (no default) on the health gauge, mirroring `crash_vol_shock`; source guards confirm the roll trigger and scenario table source it from the IPS. The shipped `config/ips.yaml` sets `skew_steepening: 0.10` explicitly.

### Confirmation (close-out)

Full gate green — **pytest 1332 passed / 2 xfailed**, mypy clean, ruff check + format clean, pylint 10.00/10.

| Property | Confirmed |
| --- | --- |
| §4 book convexity | **+24.64%** (V_crash ≈ $5.23M, 17.5×), 0.36pp under the +25% ceiling |
| Canonical convexity | **+16.10%** (valuation 2026-07-25) — in-band, +1.10pp over the +15% floor, not re-sized |
| Book == candidate at equal depth | per-contract crash payoff identical (K5280: $109,754.31 both paths) |
| Composition invariance | held leg's crash vol byte-identical after adding a deeper put |
| `skew = 0` no-op | V_crash byte-identical to the parameter-omitted call |
| No silent skew default | gauge + candidate require it; every book surface sources it from the IPS |

**Resolved:** book/candidate split and composition-dependence closed; the ≈23% sizing over-hedge bias is gone. **Remaining deferral:** the shock's term structure beyond the per-leg tenor the delta anchor already captures (methodology §8).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
